### PR TITLE
Filter map notes by geohash around user location

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "embla-carousel-react": "^8.6.0",
         "firebase": "^11.9.1",
         "genkit": "^1.14.1",
+        "geofire-common": "^6.0.0",
         "lucide-react": "^0.475.0",
         "maplibre-gl": "^4.1.0",
         "next": "15.3.3",
@@ -8602,6 +8603,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/geofire-common": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/geofire-common/-/geofire-common-6.0.0.tgz",
+      "integrity": "sha512-dQ2qKWMtHUEKT41Kw4dmAtMjvEyhWv1XPnHHlK5p5l5+0CgwHYQjhonGE2QcPP60cBYijbJ/XloeKDMU4snUQg==",
+      "license": "MIT"
     },
     "node_modules/geojson-vt": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "embla-carousel-react": "^8.6.0",
     "firebase": "^11.9.1",
     "genkit": "^1.14.1",
+    "geofire-common": "^6.0.0",
     "lucide-react": "^0.475.0",
     "maplibre-gl": "^4.1.0",
     "next": "15.3.3",


### PR DESCRIPTION
## Summary
- query Firestore using geohash bounds around the user's coordinates
- cap note retrieval to a server-side limit to prevent large result sets
- include accuracy when targeting notes for CompassView

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: prompts for ESLint config)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b724bb51fc8321b909f620e85ff540