### PR TITLE
Add tests for toast reducer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,5 +16,6 @@ Run the following commands and ensure they pass before committing:
 ```bash
 npm run lint
 npm run typecheck
+npm test
 ```
 

--- a/src/hooks/use-toast.test.ts
+++ b/src/hooks/use-toast.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest"
+
+import { reducer } from "./use-toast"
+
+describe("toast reducer", () => {
+  it("adds a toast", () => {
+    const toast = { id: "1", title: "Hello", open: true }
+    const state = reducer({ toasts: [] }, { type: "ADD_TOAST", toast } as any)
+    expect(state.toasts).toHaveLength(1)
+    expect(state.toasts[0]).toMatchObject(toast)
+  })
+
+  it("updates a toast", () => {
+    const toast = { id: "1", title: "Hello", open: true }
+    let state = reducer({ toasts: [] }, { type: "ADD_TOAST", toast } as any)
+    state = reducer(state, { type: "UPDATE_TOAST", toast: { id: "1", title: "Updated" } } as any)
+    expect(state.toasts[0].title).toBe("Updated")
+  })
+
+  it("dismisses a toast", () => {
+    const toast = { id: "1", title: "Hello", open: true }
+    let state = reducer({ toasts: [] }, { type: "ADD_TOAST", toast } as any)
+    state = reducer(state, { type: "DISMISS_TOAST", toastId: "1" })
+    expect(state.toasts[0].open).toBe(false)
+  })
+
+  it("dismisses all toasts when no id provided", () => {
+    const toast1 = { id: "1", title: "One", open: true }
+    const toast2 = { id: "2", title: "Two", open: true }
+    let state = { toasts: [toast1, toast2] } as any
+    state = reducer(state, { type: "DISMISS_TOAST" } as any)
+    expect(state.toasts).toHaveLength(2)
+    expect(state.toasts.every((t) => t.open === false)).toBe(true)
+  })
+
+  it("removes a toast", () => {
+    const toast = { id: "1", title: "Hello", open: true }
+    let state = reducer({ toasts: [] }, { type: "ADD_TOAST", toast } as any)
+    state = reducer(state, { type: "REMOVE_TOAST", toastId: "1" })
+    expect(state.toasts).toHaveLength(0)
+  })
+
+  it("removes all toasts when no id provided", () => {
+    const toast1 = { id: "1", title: "One", open: true }
+    const toast2 = { id: "2", title: "Two", open: true }
+    let state = { toasts: [toast1, toast2] } as any
+    state = reducer(state, { type: "REMOVE_TOAST" } as any)
+    expect(state.toasts).toHaveLength(0)
+  })
+
+  it("keeps only the most recent toast", () => {
+    const toast1 = { id: "1", open: true }
+    const toast2 = { id: "2", open: true }
+    let state = reducer({ toasts: [] }, { type: "ADD_TOAST", toast: toast1 } as any)
+    state = reducer(state, { type: "ADD_TOAST", toast: toast2 } as any)
+    expect(state.toasts).toHaveLength(1)
+    expect(state.toasts[0].id).toBe("2")
+  })
+})


### PR DESCRIPTION
## Summary
- expand toast reducer tests to cover dismissing and removing all toasts
- document running `npm test` in AGENTS instructions

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b7823c60ec8321b5ba9dfc378f4af3