### PR TITLE
fix: remove component-level MapLibre CSS import

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -41,7 +41,6 @@ import { db } from '@/lib/firebase';
 import { Skeleton } from './ui/skeleton';
 import { useSearchParams } from 'next/navigation';
 import { ThemeToggle } from './theme-toggle';
-import 'maplibre-gl/dist/maplibre-gl.css';
 
 const DEFAULT_CENTER = { latitude: 34.052235, longitude: -118.243683 };
 const DEFAULT_ZOOM = 16;


### PR DESCRIPTION
## Summary
- remove redundant MapLibre CSS import from `map-view`

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b783f35c7c83219c10f3be6a930afd