### PR TITLE
refactor: extract MapView Firestore logic into hook

### DIFF
--- a/src/hooks/use-notes.test.ts
+++ b/src/hooks/use-notes.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+import { getDocs } from 'firebase/firestore'
+
+vi.mock('firebase/firestore', () => ({
+  collection: vi.fn(),
+  query: vi.fn(),
+  orderBy: vi.fn(),
+  startAt: vi.fn(),
+  endAt: vi.fn(),
+  limit: vi.fn(),
+  where: vi.fn(),
+  getDocs: vi.fn(),
+}))
+
+vi.mock('geofire-common', () => ({
+  geohashQueryBounds: vi.fn(() => [['a', 'b']]),
+  distanceBetween: vi.fn(() => 0),
+}))
+
+vi.mock('../lib/firebase', () => ({ db: {} }))
+
+describe('useNotes', () => {
+  test('fetches and sets notes', async () => {
+    ;(getDocs as any).mockResolvedValue({
+      docs: [
+        {
+          id: '1',
+          data: () => ({ lat: 1, lng: 2, teaser: 't', type: 'text', score: 1, createdAt: null }),
+        },
+      ],
+    })
+    const { useNotes } = await import('./use-notes')
+    const { result } = renderHook(() => useNotes())
+    await act(async () => {
+      await result.current.fetchNotes([0, 0])
+    })
+    await waitFor(() => expect(result.current.notes).toHaveLength(1))
+    expect(getDocs).toHaveBeenCalled()
+    expect(result.current.loading).toBe(false)
+  })
+})
+

--- a/src/hooks/use-notes.ts
+++ b/src/hooks/use-notes.ts
@@ -1,0 +1,89 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import {
+  collection,
+  query,
+  orderBy,
+  startAt,
+  endAt,
+  limit,
+  getDocs,
+  Timestamp,
+  QuerySnapshot,
+  QueryDocumentSnapshot,
+  DocumentData,
+  where,
+} from "firebase/firestore";
+import { geohashQueryBounds, distanceBetween } from "geofire-common";
+import { db } from "../lib/firebase";
+import { GhostNote } from "@/types";
+
+const RADIUS_M = 5000;
+const MAX_NOTES = 50;
+
+export function useNotes() {
+  const [notes, setNotes] = useState<GhostNote[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const fetchNotes = useCallback(async (center: [number, number]) => {
+    if (!db) return;
+    setLoading(true);
+
+    const bounds = geohashQueryBounds(center, RADIUS_M);
+
+    const promises = bounds.map((b: [string, string]) =>
+      getDocs(
+        query(
+          collection(db, "notes"),
+          where("visibility", "==", "public"),
+          orderBy("geohash"),
+          startAt(b[0]),
+          endAt(b[1]),
+          limit(MAX_NOTES)
+        )
+      )
+    );
+
+    try {
+      const snapshots: QuerySnapshot<DocumentData>[] = await Promise.all(promises);
+      const notesData: GhostNote[] = [];
+      const seen = new Set<string>();
+
+      snapshots.forEach((snap: QuerySnapshot<DocumentData>) => {
+        snap.docs.forEach((doc: QueryDocumentSnapshot<DocumentData>) => {
+          if (seen.has(doc.id)) return;
+          const data = doc.data();
+          const distanceInKm = distanceBetween([data.lat, data.lng], center);
+          if (distanceInKm * 1000 <= RADIUS_M) {
+            seen.add(doc.id);
+            const createdAtTimestamp = data.createdAt as Timestamp | null;
+            notesData.push({
+              id: doc.id,
+              lat: data.lat,
+              lng: data.lng,
+              teaser: data.teaser,
+              type: data.type,
+              score: data.score,
+              createdAt: createdAtTimestamp
+                ? {
+                    seconds: createdAtTimestamp.seconds,
+                    nanoseconds: createdAtTimestamp.nanoseconds,
+                  }
+                : { seconds: Date.now() / 1000, nanoseconds: 0 },
+            });
+          }
+        });
+      });
+
+      setNotes(notesData.slice(0, MAX_NOTES));
+    } catch (error) {
+      console.error("Error fetching notes: ", error);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return { notes, loading, fetchNotes };
+}
+


### PR DESCRIPTION
## Summary
- move Firestore note queries into `useNotes` hook
- simplify `MapView` by consuming new hook
- add unit test for note fetching

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b80f497d188321a3eb356bc4e10b4d