### PR TITLE
Prevent flickering from repeated note fetches

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -45,6 +45,7 @@ function MapViewContent() {
   const mapRef = useRef<MapRef | null>(null);
   const moveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastFetchCenterRef = useRef<[number, number] | null>(null);
+  const lastFetchTimeRef = useRef<number>(0);
   const searchParams = useSearchParams();
   const { theme } = useTheme();
 
@@ -107,8 +108,10 @@ function MapViewContent() {
         const prevCenter = lastFetchCenterRef.current;
         const movedMeters =
           prevCenter ? distanceBetween(prevCenter, newCenter) * 1000 : Infinity;
-        if (movedMeters >= 50) {
+        const now = Date.now();
+        if (movedMeters >= 50 && now - lastFetchTimeRef.current > 5000) {
           lastFetchCenterRef.current = newCenter;
+          lastFetchTimeRef.current = now;
           fetchNotes(newCenter);
         }
       }


### PR DESCRIPTION
## Summary
- debounce note fetching so map markers don't refresh every couple seconds

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b81aa2c2cc8321b46aea6350ea382e