### PR TITLE
feat: add PWA install prompt

### DIFF
--- a/src/components/pwa.tsx
+++ b/src/components/pwa.tsx
@@ -1,8 +1,12 @@
 "use client";
 
 import { useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { useInstallPrompt } from '@/hooks/use-install-prompt';
 
 export function Pwa() {
+  const { isInstallable, promptInstall } = useInstallPrompt();
+
   useEffect(() => {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker
@@ -11,5 +15,11 @@ export function Pwa() {
     }
   }, []);
 
-  return null;
+  if (!isInstallable) return null;
+
+  return (
+    <div className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2">
+      <Button onClick={promptInstall}>Install App</Button>
+    </div>
+  );
 }

--- a/src/hooks/use-install-prompt.test.ts
+++ b/src/hooks/use-install-prompt.test.ts
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { renderHook, act } from '@testing-library/react';
+import { describe, test, expect, vi } from 'vitest';
+import { useInstallPrompt } from './use-install-prompt';
+
+describe('useInstallPrompt', () => {
+  test('captures event and triggers prompt', async () => {
+    const promptMock = vi.fn().mockResolvedValue(undefined);
+    const event = new Event('beforeinstallprompt') as BeforeInstallPromptEvent;
+    (event as any).prompt = promptMock;
+    (event as any).platforms = [];
+    (event as any).userChoice = Promise.resolve({ outcome: 'accepted', platform: '' });
+
+    const { result } = renderHook(() => useInstallPrompt());
+
+    act(() => {
+      window.dispatchEvent(event);
+    });
+
+    expect(result.current.isInstallable).toBe(true);
+
+    await act(async () => {
+      await result.current.promptInstall();
+    });
+
+    expect(promptMock).toHaveBeenCalled();
+    expect(result.current.isInstallable).toBe(false);
+  });
+});

--- a/src/hooks/use-install-prompt.ts
+++ b/src/hooks/use-install-prompt.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState, useEffect, useCallback } from 'react';
+
+export function useInstallPrompt() {
+  const [promptEvent, setPromptEvent] = useState<BeforeInstallPromptEvent | null>(null);
+
+  useEffect(() => {
+    const handler = (e: BeforeInstallPromptEvent) => {
+      e.preventDefault();
+      setPromptEvent(e);
+    };
+    window.addEventListener('beforeinstallprompt', handler);
+    return () => window.removeEventListener('beforeinstallprompt', handler);
+  }, []);
+
+  const promptInstall = useCallback(async () => {
+    if (!promptEvent) return;
+    await promptEvent.prompt();
+    setPromptEvent(null);
+  }, [promptEvent]);
+
+  return { isInstallable: !!promptEvent, promptInstall };
+}

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -2,3 +2,13 @@ declare module 'geofire-common';
 declare module 'vitest';
 declare module 'next-themes';
 declare module 'next-themes/dist/types';
+
+interface BeforeInstallPromptEvent extends Event {
+  readonly platforms: string[];
+  readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+  prompt(): Promise<void>;
+}
+
+interface WindowEventMap {
+  beforeinstallprompt: BeforeInstallPromptEvent;
+}


### PR DESCRIPTION
## Summary
- add install prompt hook and button
- define BeforeInstallPromptEvent types
- add tests for install prompt

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b827b71c948321bc4d4e036f14a614