### PR TITLE
Improve note sheet responsiveness across devices

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -302,7 +302,10 @@ function MapViewContent() {
       </Button>
 
       <Sheet open={isNoteSheetOpen} onOpenChange={setNoteSheetOpen}>
-        <SheetContent side="bottom" className="md:max-w-md md:right-0 md:left-auto md:top-0 md:h-full md:rounded-l-2xl">
+        <SheetContent
+          side="bottom"
+          className="max-h-[90vh] overflow-y-auto md:max-h-none md:right-0 md:left-auto md:top-0 md:h-full md:rounded-l-2xl md:max-w-md lg:max-w-lg xl:max-w-xl"
+        >
           <NoteSheetContent
             noteId={selectedNote?.id ?? null}
             isCreating={isCreatingNote}


### PR DESCRIPTION
## Summary
- limit note sheet height on mobile and allow scrolling
- widen note sheet on larger screens for better desktop viewing

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85b8c41188321a047fa21f6ecddb7