### PR TITLE
feat: expose error state in useNotes

### DIFF
--- a/src/hooks/use-notes.test.ts
+++ b/src/hooks/use-notes.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { renderHook, act, waitFor } from '@testing-library/react'
-import { describe, expect, test, vi } from 'vitest'
+import { describe, expect, test, vi, beforeEach } from 'vitest'
 import { getDocs } from 'firebase/firestore'
 
 vi.mock('firebase/firestore', () => ({
@@ -21,6 +21,10 @@ vi.mock('geofire-common', () => ({
 
 vi.mock('../lib/firebase', () => ({ db: {} }))
 
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
 describe('useNotes', () => {
   test('fetches and sets notes', async () => {
     ;(getDocs as any).mockResolvedValue({
@@ -39,6 +43,45 @@ describe('useNotes', () => {
     await waitFor(() => expect(result.current.notes).toHaveLength(1))
     expect(getDocs).toHaveBeenCalled()
     expect(result.current.loading).toBe(false)
+    expect(result.current.error).toBeNull()
+  })
+
+  test('propagates fetch errors', async () => {
+    ;(getDocs as any).mockRejectedValue(new Error('boom'))
+    const { useNotes } = await import('./use-notes')
+    const { result } = renderHook(() => useNotes())
+    await act(async () => {
+      await result.current.fetchNotes([0, 0])
+    })
+    await waitFor(() => expect(result.current.error).toBe('boom'))
+    expect(result.current.loading).toBe(false)
+  })
+
+  test('clears error after successful fetch', async () => {
+    ;(getDocs as any)
+      .mockRejectedValueOnce(new Error('fail'))
+      .mockResolvedValue({
+        docs: [
+          {
+            id: '1',
+            data: () => ({ lat: 1, lng: 2, teaser: 't', type: 'text', score: 1, createdAt: null }),
+          },
+        ],
+      })
+
+    const { useNotes } = await import('./use-notes')
+    const { result } = renderHook(() => useNotes())
+
+    await act(async () => {
+      await result.current.fetchNotes([0, 0])
+    })
+    await waitFor(() => expect(result.current.error).toBe('fail'))
+
+    await act(async () => {
+      await result.current.fetchNotes([0, 0])
+    })
+    await waitFor(() => expect(result.current.error).toBeNull())
+    expect(result.current.notes).toHaveLength(1)
   })
 })
 

--- a/src/hooks/use-notes.ts
+++ b/src/hooks/use-notes.ts
@@ -25,6 +25,7 @@ const MAX_NOTES = 50;
 export function useNotes() {
   const [notes, setNotes] = useState<GhostNote[]>([]);
   const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   const fetchNotes = useCallback(async (center: [number, number]) => {
     if (!db) return;
@@ -77,13 +78,15 @@ export function useNotes() {
       });
 
       setNotes(notesData.slice(0, MAX_NOTES));
-    } catch (error) {
-      console.error("Error fetching notes: ", error);
+      setError(null);
+    } catch (err) {
+      console.error("Error fetching notes: ", err);
+      setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
     }
   }, []);
 
-  return { notes, loading, fetchNotes };
+  return { notes, loading, fetchNotes, error };
 }
 


### PR DESCRIPTION
## Summary
- track and expose a fetch error in `useNotes`
- test error handling and reset behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85cd120248321a12ec25c325fa41b