### PR TITLE
feat: support browsers without permissions api

### DIFF
--- a/src/hooks/use-location.test.ts
+++ b/src/hooks/use-location.test.ts
@@ -48,6 +48,28 @@ describe('useLocation', () => {
     expect(result.current.error).toMatch('Denied')
   })
 
+  test('falls back when Permissions API is unsupported', async () => {
+    const mockWatch = vi.fn((success: any) => {
+      success({ coords: { latitude: 4, longitude: 5, accuracy: 6 } })
+      return 1
+    })
+    const mockClear = vi.fn()
+    Object.defineProperty(navigator, 'geolocation', {
+      value: { watchPosition: mockWatch, clearWatch: mockClear },
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'permissions', { value: undefined, configurable: true })
+
+    const { result, unmount } = renderHook(() => useLocation())
+    await waitFor(() =>
+      expect(result.current.location).toEqual({ latitude: 4, longitude: 5, accuracy: 6 })
+    )
+    expect(result.current.permissionState).toBe('granted')
+    unmount()
+    expect(mockWatch).toHaveBeenCalled()
+    expect(mockClear).toHaveBeenCalled()
+  })
+
   test('reports unsupported browser', () => {
     Object.defineProperty(navigator, 'geolocation', { value: undefined, configurable: true })
     const { result } = renderHook(() => useLocation())

--- a/src/hooks/use-location.ts
+++ b/src/hooks/use-location.ts
@@ -20,13 +20,16 @@ export function useLocation() {
       return;
     }
     
-    // Check initial permission status
-    navigator.permissions.query({ name: 'geolocation' }).then((permissionStatus) => {
+    const permissions = (navigator as any).permissions
+    // Check initial permission status if the Permissions API is supported
+    if (permissions?.query) {
+      permissions.query({ name: 'geolocation' }).then((permissionStatus: PermissionStatus) => {
         setPermissionState(permissionStatus.state);
         permissionStatus.onchange = () => {
-            setPermissionState(permissionStatus.state);
+          setPermissionState(permissionStatus.state);
         };
-    });
+      });
+    }
 
     const successHandler = (position: GeolocationPosition) => {
       setLocation({
@@ -35,15 +38,27 @@ export function useLocation() {
         accuracy: position.coords.accuracy,
       });
       setError(null);
+      setPermissionState('granted');
     };
 
     const errorHandler = (error: GeolocationPositionError) => {
       setError(`Error getting location: ${error.message}`);
+      if (error.code === error.PERMISSION_DENIED) {
+        setPermissionState('denied');
+      }
     };
-    
-    let watchId: number;
 
-    if (permissionState === 'granted') {
+    let watchId: number | undefined;
+
+    if (permissions?.query) {
+      if (permissionState === 'granted') {
+        watchId = navigator.geolocation.watchPosition(successHandler, errorHandler, {
+          enableHighAccuracy: true,
+          timeout: 10000,
+          maximumAge: 0,
+        });
+      }
+    } else {
       watchId = navigator.geolocation.watchPosition(successHandler, errorHandler, {
         enableHighAccuracy: true,
         timeout: 10000,


### PR DESCRIPTION
## Summary
- guard geolocation permission query behind existence check
- fallback to geolocation watch when Permissions API is unavailable
- add unit test for browser fallback behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b888d29e188321aa65dba53af04f1f