### PR TITLE
feat: add firebase messaging support

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -27,3 +27,31 @@ self.addEventListener('fetch', (event) => {
     caches.match(event.request).then((response) => response || fetch(event.request))
   );
 });
+
+self.addEventListener('push', (event) => {
+  const data = event.data ? event.data.json() : {};
+  const title = data.notification?.title || data.title || 'Notification';
+  const options = {
+    body: data.notification?.body || data.body,
+    icon: '/icon-192.png',
+    data: data.data || {},
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', (event) => {
+  event.notification.close();
+  const url = event.notification.data?.url;
+  if (url) {
+    event.waitUntil(
+      self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then((clientsArr) => {
+        for (const client of clientsArr) {
+          if (client.url === url) {
+            return client.focus();
+          }
+        }
+        return self.clients.openWindow(url);
+      })
+    );
+  }
+});

--- a/src/app/api/notify/route.ts
+++ b/src/app/api/notify/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { getMessaging } from 'firebase-admin/messaging';
+
+if (!getApps().length) {
+  initializeApp();
+}
+
+export async function POST(req: NextRequest) {
+  const { userId, title, body, data } = await req.json();
+  const db = getFirestore();
+  const tokenDoc = await db.collection('fcmTokens').doc(userId).get();
+  const tokens = tokenDoc.exists ? tokenDoc.data()?.tokens || [] : [];
+  if (!tokens.length) {
+    return NextResponse.json({ success: false, error: 'No tokens' }, { status: 404 });
+  }
+  await getMessaging().sendEachForMulticast({
+    tokens,
+    notification: { title, body },
+    data: data || {},
+  });
+  return NextResponse.json({ success: true });
+}

--- a/src/components/note-sheet-content.tsx
+++ b/src/components/note-sheet-content.tsx
@@ -306,6 +306,16 @@ function ReplyForm({ noteId, noteAuthorUid }: { noteId: string, noteAuthorUid?: 
                      createdAt: serverTimestamp(),
                      read: false,
                  });
+                 fetch('/api/notify', {
+                     method: 'POST',
+                     headers: { 'Content-Type': 'application/json' },
+                     body: JSON.stringify({
+                         userId: noteAuthorUid,
+                         title: 'New reply',
+                         body: `${pseudonym} replied to your note`,
+                         data: { noteId, type: 'reply' }
+                     })
+                 }).catch(() => {});
              }
 
              setText("");
@@ -542,6 +552,16 @@ function NoteView({ note: initialNote, onClose }: {note: Note, onClose: () => vo
                   createdAt: serverTimestamp(),
                   read: false,
               });
+              fetch('/api/notify', {
+                  method: 'POST',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({
+                      userId: note.authorUid,
+                      title: 'New like',
+                      body: `${pseudonym} liked your note`,
+                      data: { noteId: note.id, type: 'like' }
+                  })
+              }).catch(() => {});
           }
       } catch (error: any) {
           console.error("Transaction failed: ", error);

--- a/src/components/pwa.tsx
+++ b/src/components/pwa.tsx
@@ -3,9 +3,11 @@
 import { useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import { useInstallPrompt } from '@/hooks/use-install-prompt';
+import { useFcmToken } from '@/hooks/use-fcm-token';
 
 export function Pwa() {
   const { isInstallable, promptInstall } = useInstallPrompt();
+  useFcmToken();
 
   useEffect(() => {
     if ('serviceWorker' in navigator) {

--- a/src/hooks/use-fcm-token.test.ts
+++ b/src/hooks/use-fcm-token.test.ts
@@ -1,0 +1,32 @@
+// @vitest-environment jsdom
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+vi.mock('firebase/messaging', () => ({ getToken: vi.fn(() => Promise.resolve('token-123')) }));
+vi.mock('firebase/firestore', () => ({
+  doc: vi.fn(() => ({})),
+  setDoc: vi.fn(() => Promise.resolve()),
+  arrayUnion: vi.fn((v: any) => v),
+}));
+vi.mock('@/lib/firebase', () => ({ messaging: {}, db: {} }));
+vi.mock('@/components/auth-provider', () => ({ useAuth: vi.fn() }));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useFcmToken', () => {
+  test('requests permission and stores token', async () => {
+    const { useAuth } = await import('@/components/auth-provider');
+    (useAuth as any).mockReturnValue({ user: { uid: 'u1' } });
+    (global as any).Notification = {
+      requestPermission: vi.fn(() => Promise.resolve('granted')),
+    };
+    const { useFcmToken } = await import('./use-fcm-token');
+    renderHook(() => useFcmToken());
+    const { getToken } = await import('firebase/messaging');
+    const { setDoc } = await import('firebase/firestore');
+    await waitFor(() => expect((getToken as any)).toHaveBeenCalled());
+    await waitFor(() => expect((setDoc as any)).toHaveBeenCalled());
+  });
+});

--- a/src/hooks/use-fcm-token.ts
+++ b/src/hooks/use-fcm-token.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from 'react';
+import { getToken } from 'firebase/messaging';
+import { doc, setDoc, arrayUnion } from 'firebase/firestore';
+import { messaging, db } from '@/lib/firebase';
+import { useAuth } from '@/components/auth-provider';
+
+export function useFcmToken() {
+  const { user } = useAuth();
+
+  useEffect(() => {
+    async function updateToken() {
+      if (!user || !messaging || !db) return;
+      try {
+        const permission = await Notification.requestPermission();
+        if (permission !== 'granted') return;
+        const token = await getToken(messaging, {
+          vapidKey: process.env.NEXT_PUBLIC_FCM_VAPID_KEY,
+        });
+        if (!token) return;
+        await setDoc(
+          doc(db, 'fcmTokens', user.uid),
+          { tokens: arrayUnion(token) },
+          { merge: true }
+        );
+      } catch (err) {
+        console.error('Unable to get FCM token', err);
+      }
+    }
+
+    updateToken();
+  }, [user]);
+}

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -3,6 +3,7 @@ import { FirebaseApp, getApp, getApps, initializeApp } from 'firebase/app';
 import { Auth, getAuth } from 'firebase/auth';
 import { Firestore, getFirestore } from 'firebase/firestore';
 import { FirebaseStorage, getStorage } from 'firebase/storage';
+import { Messaging, getMessaging } from 'firebase/messaging';
 
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
@@ -19,6 +20,7 @@ let app: FirebaseApp;
 let auth: Auth;
 let db: Firestore;
 let storage: FirebaseStorage;
+let messaging: Messaging;
 
 // This file is intended for client-side Firebase initialization.
 // Server-side initialization should be done in the respective server files (e.g., Genkit flows).
@@ -31,15 +33,22 @@ if (typeof window !== 'undefined' && isFirebaseConfigured) {
   auth = getAuth(app);
   db = getFirestore(app);
   storage = getStorage(app);
+  try {
+    messaging = getMessaging(app);
+  } catch (err) {
+    console.warn('Firebase messaging is not supported in this environment.', err);
+    messaging = undefined as unknown as Messaging;
+  }
 } else {
   // Assign placeholders to preserve types when Firebase isn't configured.
   app = undefined as unknown as FirebaseApp;
   auth = undefined as unknown as Auth;
   db = undefined as unknown as Firestore;
   storage = undefined as unknown as FirebaseStorage;
+  messaging = undefined as unknown as Messaging;
   if (typeof window !== 'undefined') {
     console.warn('Firebase configuration is incomplete. Authentication features will be disabled.');
   }
 }
 
-export { app, auth, db, storage, isFirebaseConfigured };
+export { app, auth, db, storage, messaging, isFirebaseConfigured };


### PR DESCRIPTION
## Summary
- set up Firebase messaging and token persistence
- handle push notifications and display in service worker
- send FCM notifications when notes get likes or replies

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b888e13de083219e23ee2b9720111b