### PR TITLE
Add service worker runtime caching for tiles and notes

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,29 +1,63 @@
-const CACHE = 'notedrop-cache-v1';
-const ASSETS = [
-  '/manifest.json',
-  '/icon-192.png',
-  '/icon-512.png',
-];
+const CACHE_VERSION = 'v1';
+const STATIC_CACHE = `notedrop-cache-${CACHE_VERSION}`;
+const TILE_CACHE = `notedrop-tiles-${CACHE_VERSION}`;
+const API_CACHE = `notedrop-api-${CACHE_VERSION}`;
+const ASSETS = ['/manifest.json', '/icon-192.png', '/icon-512.png'];
 
 self.addEventListener('install', (event) => {
-  event.waitUntil(
-    caches.open(CACHE).then((cache) => cache.addAll(ASSETS))
-  );
+  event.waitUntil(caches.open(STATIC_CACHE).then((cache) => cache.addAll(ASSETS)));
 });
 
 self.addEventListener('activate', (event) => {
-  event.waitUntil(self.clients.claim());
+  const allowed = [STATIC_CACHE, TILE_CACHE, API_CACHE];
+  event.waitUntil(
+    caches
+      .keys()
+      .then((keys) =>
+        Promise.all(keys.map((key) => (allowed.includes(key) ? undefined : caches.delete(key))))
+      )
+      .then(() => self.clients.claim())
+  );
 });
 
 self.addEventListener('fetch', (event) => {
+  const url = new URL(event.request.url);
+
   if (event.request.mode === 'navigate') {
+    event.respondWith(fetch(event.request).catch(() => caches.match(event.request)));
+    return;
+  }
+
+  // Cache map tiles with a cache-first strategy
+  if (url.hostname.includes('tile') || url.pathname.includes('/tiles/')) {
     event.respondWith(
-      fetch(event.request).catch(() => caches.match(event.request))
+      caches.open(TILE_CACHE).then((cache) =>
+        cache.match(event.request).then((cached) => {
+          if (cached) return cached;
+          return fetch(event.request).then((response) => {
+            cache.put(event.request, response.clone());
+            return response;
+          });
+        })
+      )
     );
     return;
   }
 
-  event.respondWith(
-    caches.match(event.request).then((response) => response || fetch(event.request))
-  );
+  // Network-first for note API
+  if (url.pathname.startsWith('/api/notes')) {
+    event.respondWith(
+      caches.open(API_CACHE).then((cache) =>
+        fetch(event.request)
+          .then((response) => {
+            cache.put(event.request, response.clone());
+            return response;
+          })
+          .catch(() => cache.match(event.request))
+      )
+    );
+    return;
+  }
+
+  event.respondWith(caches.match(event.request).then((response) => response || fetch(event.request)));
 });

--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import vm from 'vm';
+
+// Simple service worker environment
+function setupSW() {
+  const listeners: Record<string, (event: any) => void> = {};
+  (globalThis as any).self = {
+    addEventListener: (type: string, cb: (event: any) => void) => {
+      listeners[type] = cb;
+    },
+    clients: { claim: vi.fn() },
+  };
+
+  const cachesStore = new Map<string, Map<string, Response>>();
+  (globalThis as any).caches = {
+    open: async (name: string) => {
+      if (!cachesStore.has(name)) cachesStore.set(name, new Map());
+      const store = cachesStore.get(name)!;
+      return {
+        match: async (req: Request) => store.get(req.url),
+        put: async (req: Request, res: Response) => {
+          store.set(req.url, res);
+        },
+        delete: async (req: Request) => {
+          store.delete(req.url);
+        },
+      };
+    },
+    match: async (req: Request) => {
+      for (const store of cachesStore.values()) {
+        const found = store.get(req.url);
+        if (found) return found;
+      }
+      return undefined;
+    },
+    keys: async () => Array.from(cachesStore.keys()),
+    delete: async (name: string) => {
+      cachesStore.delete(name);
+    },
+  };
+
+  const code = readFileSync(path.join(__dirname, '../public/sw.js'), 'utf8');
+  vm.runInNewContext(code, {
+    self: (globalThis as any).self,
+    caches: (globalThis as any).caches,
+    fetch: (...args: any[]) => (globalThis as any).fetch(...args),
+    URL,
+    Request,
+    Response,
+  });
+
+  return listeners;
+}
+
+describe('service worker caching', () => {
+  let listeners: Record<string, (event: any) => void>;
+
+  beforeEach(() => {
+    listeners = setupSW();
+  });
+
+  it('caches map tiles with cache-first strategy', async () => {
+    const fetchMock = vi.fn(async () => new Response('tile'));
+    (globalThis as any).fetch = fetchMock;
+
+    const request = new Request('https://tile.openstreetmap.org/0/0/0.png');
+    let resPromise: Promise<Response> | undefined;
+    listeners.fetch({
+      request,
+      respondWith: (p: Promise<Response>) => {
+        resPromise = p;
+      },
+    });
+    await resPromise!;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Second request should hit cache
+    fetchMock.mockClear();
+    listeners.fetch({
+      request,
+      respondWith: (p: Promise<Response>) => {
+        resPromise = p;
+      },
+    });
+    await resPromise!;
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('serves cached note API responses when offline', async () => {
+    const fetchMock = vi.fn(async () => new Response('note-data'));
+    (globalThis as any).fetch = fetchMock;
+
+    const request = new Request('https://example.com/api/notes');
+    let resPromise: Promise<Response> | undefined;
+    listeners.fetch({
+      request,
+      respondWith: (p: Promise<Response>) => {
+        resPromise = p;
+      },
+    });
+    await resPromise!;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    // Offline: network fails, should return cached response
+    fetchMock.mockRejectedValueOnce(new Error('Network fail'));
+    listeners.fetch({
+      request,
+      respondWith: (p: Promise<Response>) => {
+        resPromise = p;
+      },
+    });
+    const res = await resPromise!;
+    expect(await res.text()).toBe('note-data');
+  });
+});


### PR DESCRIPTION
## Summary
- cache map tiles with cache-first strategy and versioned caches
- add versioned caching for note API responses with old cache cleanup
- test service worker caching for tiles and offline note API

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b888da6d208321a89fec26a76a01fc