### PR TITLE
fix: skip caching non-GET note requests

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -46,6 +46,12 @@ self.addEventListener('fetch', (event) => {
 
   // Network-first for note API
   if (url.pathname.startsWith('/api/notes')) {
+    // Only cache GET requests; forward all other methods to the network
+    if (event.request.method !== 'GET') {
+      event.respondWith(fetch(event.request));
+      return;
+    }
+
     event.respondWith(
       caches.open(API_CACHE).then((cache) =>
         fetch(event.request)


### PR DESCRIPTION
## Summary
- skip service worker caching for non-GET note API requests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b88afd6fc0832190b5aa8754b33a2b