### PR TITLE
Add Firebase messaging service worker

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,0 +1,15 @@
+importScripts('https://www.gstatic.com/firebasejs/11.9.1/firebase-app-compat.js');
+importScripts('https://www.gstatic.com/firebasejs/11.9.1/firebase-messaging-compat.js');
+importScripts('/__/firebase/init.js');
+
+const messaging = firebase.messaging();
+
+messaging.onBackgroundMessage((payload) => {
+  const notificationTitle = payload.notification?.title ?? 'Notification';
+  const notificationOptions = {
+    body: payload.notification?.body,
+    icon: '/icon-192.png',
+  };
+
+  self.registration.showNotification(notificationTitle, notificationOptions);
+});


### PR DESCRIPTION
## Summary
- serve Firebase Cloud Messaging service worker to support push notifications

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8936e335483219885efac78b7cd32