### PR TITLE
Add Firebase messaging service worker

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -1,6 +1,8 @@
 importScripts('https://www.gstatic.com/firebasejs/11.9.1/firebase-app-compat.js');
 importScripts('https://www.gstatic.com/firebasejs/11.9.1/firebase-messaging-compat.js');
-importScripts('/__/firebase/init.js');
+importScripts('/firebase-config.js');
+
+firebase.initializeApp(self.firebaseConfig);
 
 const messaging = firebase.messaging();
 

--- a/src/app/firebase-config.js/route.ts
+++ b/src/app/firebase-config.js/route.ts
@@ -1,0 +1,14 @@
+export function GET() {
+  const firebaseConfig = {
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: process.env.NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  };
+
+  return new Response(`self.firebaseConfig = ${JSON.stringify(firebaseConfig)}` , {
+    headers: { 'Content-Type': 'application/javascript' },
+  });
+}


### PR DESCRIPTION
## Summary
- serve Firebase Cloud Messaging service worker to support push notifications
- initialize Firebase inside service worker using environment config
- expose `firebase-config.js` route to supply config without Firebase Hosting

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b89b2f4204832188cb8ce56b383bbc