### PR TITLE
fix: use service worker for proximity notifications

### DIFF
--- a/src/hooks/use-proximity-notifications.test.ts
+++ b/src/hooks/use-proximity-notifications.test.ts
@@ -40,5 +40,21 @@ describe('useProximityNotifications', () => {
       expect(showNotification).toHaveBeenCalledWith('Note nearby', { body: 'You are near a note' })
     )
   })
+
+  test('falls back to Notification API when service worker lacks showNotification', async () => {
+    const notes: GhostNote[] = [
+      { id: '1', lat: 0, lng: 0, teaser: 'hi', type: 'text', score: 0, createdAt: { seconds: 0, nanoseconds: 0 } },
+    ]
+    const location: Coordinates = { latitude: 0, longitude: 0, accuracy: 0 }
+    const notificationSpy = vi.fn()
+    ;(notificationSpy as any).permission = 'granted'
+    ;(global as any).Notification = notificationSpy
+    ;(navigator as any).serviceWorker.ready = Promise.resolve({})
+    renderHook(() => useProximityNotifications(notes, location, 100))
+    await waitFor(() =>
+      expect(notificationSpy).toHaveBeenCalledWith('Note nearby', { body: 'hi' })
+    )
+    expect(showNotification).not.toHaveBeenCalled()
+  })
 })
 

--- a/src/hooks/use-proximity-notifications.ts
+++ b/src/hooks/use-proximity-notifications.ts
@@ -26,9 +26,15 @@ export function useProximityNotifications(
       if (distance <= radiusM) {
         if ("serviceWorker" in navigator) {
           void navigator.serviceWorker.ready.then((reg) => {
-            reg.showNotification("Note nearby", {
-              body: note.teaser || "You are near a note",
-            });
+            if ("showNotification" in reg) {
+              reg.showNotification("Note nearby", {
+                body: note.teaser || "You are near a note",
+              });
+            } else {
+              new Notification("Note nearby", {
+                body: note.teaser || "You are near a note",
+              });
+            }
           });
         } else {
           new Notification("Note nearby", {


### PR DESCRIPTION
## Summary
- use `ServiceWorkerRegistration.showNotification` when proximity notifications trigger
- fall back to `new Notification` if `showNotification` is unavailable
- add tests for service worker-driven notifications and fallback

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8aa0497248321842e9495cf182249