### PR TITLE
docs: document AR stack and browser support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ NEXT_PUBLIC_PROXIMITY_RADIUS_M=100
 
 If not provided, the default radius is 50 meters.
 
+## Browser & Device Support
+
+| Device/OS | Browser | AR Support | Notes |
+|-----------|---------|------------|-------|
+| Android (ARCore capable) | Chrome 81+ | ✅ WebXR AR | Requires HTTPS and camera permissions |
+| Android (ARCore capable) | Samsung Internet 14+ | ✅ WebXR AR | May require enabling experimental WebXR flag |
+| iOS 15+ | Safari | ❌ No WebXR | Falls back to non-AR experience |
+| Desktop (Windows/macOS) | Chrome, Edge, Firefox | ❌ | AR features require mobile hardware |
+
 ## Documentation
 
 A high level project blueprint is available in [`docs/blueprint.md`](docs/blueprint.md).

--- a/docs/ar/stack.md
+++ b/docs/ar/stack.md
@@ -1,0 +1,27 @@
+# AR Stack Evaluation
+
+## WebXR via three.js or A-Frame
+
+- Runs directly in modern browsers without app store deployment.
+- `three.js` offers fine-grained control and strong TypeScript support.
+- `A-Frame` provides a declarative layer but adds extra overhead.
+- Browser support is limited: effective today on Chrome and Samsung Internet for ARCore-capable Android devices; iOS Safari lacks WebXR.
+- Tracking and performance depend on browser implementations and may lag behind native capabilities.
+
+## Native ARKit/ARCore Wrappers
+
+- Full access to device sensors and the latest AR features with best performance.
+- Requires building and maintaining separate native apps for iOS and Android.
+- Slower iteration and distribution through app stores.
+- Harder to integrate with a primarily web-based codebase.
+
+## Chosen Stack
+
+The project will use **WebXR with `three.js`**. It keeps the stack web-centric alongside Next.js, avoids native app maintenance, and allows us to progressively enhance features for supported browsers. `A-Frame` was considered but deemed heavier than necessary.
+
+## Required Polyfills
+
+- [`webxr-polyfill`](https://github.com/immersive-web/webxr-polyfill) to expose WebXR APIs on browsers without native support.
+- `@webxr-input-profiles/motion-controllers` for loading controller profiles used by `three.js` WebXR helpers.
+- Graceful degradation on iOS Safari where WebXR is unavailable.
+


### PR DESCRIPTION
## Summary
- evaluate WebXR against native ARKit/ARCore and document final choice
- detail polyfills needed for the WebXR approach
- add browser and device support matrix to README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8bbcc76c0832191f0b98d31937310