### PR TITLE
feat: add AR note creation

### DIFF
--- a/src/lib/geo.test.ts
+++ b/src/lib/geo.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { latLngToLocal } from "./geo";
+import { latLngToLocal, localToLatLng } from "./geo";
 
 describe("latLngToLocal", () => {
   test("returns zero vector at origin", () => {
@@ -22,6 +22,17 @@ describe("latLngToLocal", () => {
       { lat: 0.000008983, lng: 0 }, // ≈1m north
     );
     expect(v.z).toBeLessThan(0);
+  });
+});
+
+describe("localToLatLng", () => {
+  test("is inverse of latLngToLocal", () => {
+    const origin = { lat: 0, lng: 0 };
+    const target = { lat: 0.000008983, lng: 0.000008983 }; // ≈1m north-east
+    const local = latLngToLocal(origin, target);
+    const result = localToLatLng(origin, local);
+    expect(result.lat).toBeCloseTo(target.lat);
+    expect(result.lng).toBeCloseTo(target.lng);
   });
 });
 

--- a/src/lib/geo.ts
+++ b/src/lib/geo.ts
@@ -19,3 +19,16 @@ export function latLngToLocal(origin: LatLng, target: LatLng): THREE.Vector3 {
   return new THREE.Vector3(x, 0, z);
 }
 
+/**
+ * Convert local Cartesian coordinates back to latitude/longitude relative to an origin.
+ * Accepts a vector using meters in the X (east) and Z (south) axes.
+ */
+export function localToLatLng(origin: LatLng, point: THREE.Vector3): LatLng {
+  const dLat = -point.z / EARTH_RADIUS;
+  const dLon = point.x / (EARTH_RADIUS * Math.cos(THREE.MathUtils.degToRad(origin.lat)));
+  return {
+    lat: origin.lat + THREE.MathUtils.radToDeg(dLat),
+    lng: origin.lng + THREE.MathUtils.radToDeg(dLon),
+  };
+}
+


### PR DESCRIPTION
## Summary
- enable world hit-test note placement in AR view
- support AR-driven note creation in map view
- add localToLatLng helper with tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c0afa54083218f32e8d7ce9a2438