### PR TITLE
fix: align AR hit-test with heading

### DIFF
--- a/src/hooks/use-location.test.ts
+++ b/src/hooks/use-location.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 describe('useLocation', () => {
   test('updates location and cleans up watcher', async () => {
     const mockWatch = vi.fn((success: any) => {
-      success({ coords: { latitude: 1, longitude: 2, accuracy: 3 } })
+      success({ coords: { latitude: 1, longitude: 2, accuracy: 3, heading: 45 } })
       return 1
     })
     const mockClear = vi.fn()
@@ -26,7 +26,14 @@ describe('useLocation', () => {
     Object.defineProperty(navigator, 'permissions', { value: mockPermissions, configurable: true })
 
     const { result, unmount } = renderHook(() => useLocation())
-    await waitFor(() => expect(result.current.location).toEqual({ latitude: 1, longitude: 2, accuracy: 3 }))
+    await waitFor(() =>
+      expect(result.current.location).toEqual({
+        latitude: 1,
+        longitude: 2,
+        accuracy: 3,
+        heading: 45,
+      }),
+    )
     unmount()
     expect(mockClear).toHaveBeenCalledWith(1)
   })
@@ -50,7 +57,7 @@ describe('useLocation', () => {
 
   test('falls back when Permissions API is unsupported', async () => {
     const mockWatch = vi.fn((success: any) => {
-      success({ coords: { latitude: 4, longitude: 5, accuracy: 6 } })
+      success({ coords: { latitude: 4, longitude: 5, accuracy: 6, heading: 90 } })
       return 1
     })
     const mockClear = vi.fn()
@@ -62,7 +69,12 @@ describe('useLocation', () => {
 
     const { result, unmount } = renderHook(() => useLocation())
     await waitFor(() =>
-      expect(result.current.location).toEqual({ latitude: 4, longitude: 5, accuracy: 6 })
+      expect(result.current.location).toEqual({
+        latitude: 4,
+        longitude: 5,
+        accuracy: 6,
+        heading: 90,
+      }),
     )
     expect(result.current.permissionState).toBe('granted')
     unmount()

--- a/src/hooks/use-location.ts
+++ b/src/hooks/use-location.ts
@@ -6,6 +6,7 @@ export interface Coordinates {
   latitude: number;
   longitude: number;
   accuracy: number;
+  heading?: number | null;
 }
 
 export function useLocation() {
@@ -36,6 +37,7 @@ export function useLocation() {
         latitude: position.coords.latitude,
         longitude: position.coords.longitude,
         accuracy: position.coords.accuracy,
+        heading: position.coords.heading ?? null,
       });
       setError(null);
       setPermissionState('granted');
@@ -80,6 +82,7 @@ export function useLocation() {
                 latitude: position.coords.latitude,
                 longitude: position.coords.longitude,
                 accuracy: position.coords.accuracy,
+                heading: position.coords.heading ?? null,
             });
             setError(null);
             setPermissionState('granted');


### PR DESCRIPTION
## Summary
- rotate AR hit-test coordinates by session heading to get correct lat/lng
- expose optional heading from `useLocation` hook
- cover heading in `useLocation` tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c31deb448321953a231d63557fa2