### PR TITLE
fix: sanitize non-finite heading

### DIFF
--- a/src/hooks/use-location.test.ts
+++ b/src/hooks/use-location.test.ts
@@ -38,6 +38,29 @@ describe('useLocation', () => {
     expect(mockClear).toHaveBeenCalledWith(1)
   })
 
+  test('normalizes non-finite heading to null', async () => {
+    const mockWatch = vi.fn((success: any) => {
+      success({ coords: { latitude: 7, longitude: 8, accuracy: 9, heading: NaN } })
+      return 1
+    })
+    const mockPermissions = { query: vi.fn().mockResolvedValue({ state: 'granted', onchange: null }) }
+    Object.defineProperty(navigator, 'geolocation', {
+      value: { watchPosition: mockWatch, clearWatch: vi.fn(), getCurrentPosition: vi.fn() },
+      configurable: true,
+    })
+    Object.defineProperty(navigator, 'permissions', { value: mockPermissions, configurable: true })
+
+    const { result } = renderHook(() => useLocation())
+    await waitFor(() =>
+      expect(result.current.location).toEqual({
+        latitude: 7,
+        longitude: 8,
+        accuracy: 9,
+        heading: null,
+      }),
+    )
+  })
+
   test('handles permission denial on request', async () => {
     const error = { code: 1, message: 'Denied', PERMISSION_DENIED: 1 }
     Object.defineProperty(navigator, 'geolocation', {

--- a/src/hooks/use-location.ts
+++ b/src/hooks/use-location.ts
@@ -14,6 +14,9 @@ export function useLocation() {
   const [error, setError] = useState<string | null>(null);
   const [permissionState, setPermissionState] = useState<PermissionState>('prompt');
 
+  const normalizeHeading = (heading: number | null | undefined) =>
+    typeof heading === 'number' && Number.isFinite(heading) ? heading : null;
+
   useEffect(() => {
     if (!navigator.geolocation) {
       setError('Geolocation is not supported by your browser.');
@@ -37,7 +40,7 @@ export function useLocation() {
         latitude: position.coords.latitude,
         longitude: position.coords.longitude,
         accuracy: position.coords.accuracy,
-        heading: position.coords.heading ?? null,
+        heading: normalizeHeading(position.coords.heading),
       });
       setError(null);
       setPermissionState('granted');
@@ -82,7 +85,7 @@ export function useLocation() {
                 latitude: position.coords.latitude,
                 longitude: position.coords.longitude,
                 accuracy: position.coords.accuracy,
-                heading: position.coords.heading ?? null,
+                heading: normalizeHeading(position.coords.heading),
             });
             setError(null);
             setPermissionState('granted');


### PR DESCRIPTION
## Summary
- normalize `heading` to null if geolocation API returns a non-finite value
- add unit test confirming `NaN` heading is sanitized

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8c4cb71108321b6282e0929746bc9