### PR TITLE
feat: unify ar permissions and add analytics

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,51 @@
 
+"use client";
+
 import MapView from "@/components/map-view";
-import { Suspense } from "react";
+import { Suspense, useEffect, useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import Link from "next/link";
+import { trackEvent } from "@/lib/analytics";
 
 export default function Home() {
+  const [unsupported, setUnsupported] = useState(false);
+
+  useEffect(() => {
+    const supported =
+      typeof window !== "undefined" &&
+      typeof navigator.mediaDevices?.getUserMedia === "function" &&
+      "DeviceOrientationEvent" in window &&
+      (navigator as any).xr;
+    if (!supported) {
+      setUnsupported(true);
+      trackEvent("ar_launch_failed", { reason: "unsupported_environment" });
+    }
+  }, []);
+
   return (
-    <Suspense>
+    <>
+      <Suspense>
         <MapView />
-    </Suspense>
+      </Suspense>
+      <Dialog open={unsupported}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>AR Not Supported</DialogTitle>
+            <DialogDescription>
+              Your device or browser lacks camera or motion sensor support required for AR mode.
+            </DialogDescription>
+            <Link href="/" className="underline mt-4 block">
+              Return to Map
+            </Link>
+          </DialogHeader>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }

--- a/src/hooks/use-ar-mode.ts
+++ b/src/hooks/use-ar-mode.ts
@@ -2,9 +2,15 @@
 
 import { useEffect, useState } from "react";
 import { useOrientation } from "./use-orientation";
+import { trackEvent } from "@/lib/analytics";
 
 export function useARMode(threshold: number = 60) {
-  const { orientation, permissionGranted, requestPermission } = useOrientation();
+  const {
+    orientation,
+    permissionGranted: orientationGranted,
+    requestPermission: requestOrientationPermission,
+  } = useOrientation();
+  const [cameraPermissionGranted, setCameraPermissionGranted] = useState(false);
   const [isARActive, setIsARActive] = useState(false);
 
   useEffect(() => {
@@ -12,6 +18,31 @@ export function useARMode(threshold: number = 60) {
       setIsARActive(orientation.beta > threshold);
     }
   }, [orientation.beta, threshold]);
+
+  const permissionGranted = orientationGranted && cameraPermissionGranted;
+
+  const requestPermission = async () => {
+    const orient = await requestOrientationPermission();
+    if (!orient) {
+      trackEvent("ar_permission_denied", { type: "orientation" });
+      trackEvent("ar_launch_failed", { reason: "orientation_denied" });
+      return false;
+    }
+    if (!navigator.mediaDevices?.getUserMedia) {
+      trackEvent("ar_launch_failed", { reason: "media_devices_unsupported" });
+      return false;
+    }
+    try {
+      await navigator.mediaDevices.getUserMedia({ video: true });
+      setCameraPermissionGranted(true);
+      return true;
+    } catch {
+      setCameraPermissionGranted(false);
+      trackEvent("ar_permission_denied", { type: "camera" });
+      trackEvent("ar_launch_failed", { reason: "camera_denied" });
+      return false;
+    }
+  };
 
   return { isARActive, permissionGranted, requestPermission };
 }

--- a/src/hooks/use-orientation.test.ts
+++ b/src/hooks/use-orientation.test.ts
@@ -28,7 +28,8 @@ describe('useOrientation', () => {
 
     const { result, unmount } = renderHook(() => useOrientation())
     await act(async () => {
-      await result.current.requestPermission()
+      const granted = await result.current.requestPermission()
+      expect(granted).toBe(true)
     })
     expect(result.current.permissionGranted).toBe(true)
     act(() => listeners[0]({ alpha: 1, beta: 2, gamma: 3 }))
@@ -44,7 +45,8 @@ describe('useOrientation', () => {
     window.addEventListener = addSpy as any
     const { result } = renderHook(() => useOrientation())
     await act(async () => {
-      await result.current.requestPermission()
+      const granted = await result.current.requestPermission()
+      expect(granted).toBe(false)
     })
     expect(result.current.permissionGranted).toBe(false)
     expect(result.current.error).toMatch('denied')

--- a/src/hooks/use-orientation.ts
+++ b/src/hooks/use-orientation.ts
@@ -22,25 +22,29 @@ export function useOrientation() {
     });
   };
 
-  const requestPermission = async () => {
+  const requestPermission = async (): Promise<boolean> => {
     if (typeof (DeviceOrientationEvent as any).requestPermission === 'function') {
       try {
         const permissionState = await (DeviceOrientationEvent as any).requestPermission();
         if (permissionState === 'granted') {
           window.addEventListener('deviceorientation', handleOrientation);
           setPermissionGranted(true);
+          return true;
         } else {
           setError('Permission for device orientation was denied.');
           setPermissionGranted(false);
+          return false;
         }
       } catch (err) {
         setError('Error requesting device orientation permission.');
         setPermissionGranted(false);
+        return false;
       }
     } else {
       // For non-iOS 13+ browsers
       window.addEventListener('deviceorientation', handleOrientation);
       setPermissionGranted(true);
+      return true;
     }
   };
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { trackEvent } from './analytics';
+
+vi.mock('./firebase', () => ({ app: {}, isFirebaseConfigured: true }));
+vi.mock('firebase/analytics', () => ({
+  getAnalytics: vi.fn(() => ({})),
+  logEvent: vi.fn(),
+}));
+
+import { getAnalytics, logEvent } from 'firebase/analytics';
+
+beforeEach(() => {
+  (globalThis as any).window = {};
+  vi.clearAllMocks();
+});
+
+describe('trackEvent', () => {
+  test('logs events when firebase configured', () => {
+    trackEvent('test_event', { foo: 'bar' });
+    expect(getAnalytics).toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith({}, 'test_event', { foo: 'bar' });
+  });
+
+  test('does nothing when window undefined', () => {
+    const orig = globalThis.window;
+    // @ts-ignore
+    delete (globalThis as any).window;
+    trackEvent('no_window');
+    expect(logEvent).not.toHaveBeenCalled();
+    globalThis.window = orig;
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,20 @@
+import { getAnalytics, logEvent, Analytics } from 'firebase/analytics';
+import { app, isFirebaseConfigured } from './firebase';
+
+let analytics: Analytics | undefined;
+
+export function trackEvent(event: string, params?: Record<string, any>) {
+  if (typeof window === 'undefined' || !isFirebaseConfigured) return;
+  if (!analytics) {
+    try {
+      analytics = getAnalytics(app);
+    } catch {
+      return;
+    }
+  }
+  try {
+    logEvent(analytics, event, params);
+  } catch {
+    // ignore analytics errors
+  }
+}


### PR DESCRIPTION
## Summary
- add Firebase analytics helper
- consolidate AR camera and orientation permissions
- show AR unsupported modal with analytics event

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b92eb6702c8321ac3e17bf4e11fc97