### PR TITLE
Add AR frustum culling and LOD with tests

### DIFF
--- a/docs/ar/testing.md
+++ b/docs/ar/testing.md
@@ -1,0 +1,14 @@
+# AR Manual Testing Checklist
+
+## Device compatibility
+- [ ] Chrome on ARCore-capable Android device
+- [ ] Samsung Internet on ARCore-capable Android device
+- [ ] Unsupported browsers show fallback message (e.g., iOS Safari)
+
+## Permission flows
+- [ ] Camera permission prompt appears and accepting starts AR session
+- [ ] Denying camera permission shows helpful error and prevents AR session
+- [ ] Location permission prompt appears; accepting updates note positions
+- [ ] Denying location permission shows fallback message
+- [ ] Motion/Orientation sensor permission requested on iOS 13+
+- [ ] Revoking permissions and reloading triggers prompts again

--- a/src/components/ar-view.test.tsx
+++ b/src/components/ar-view.test.tsx
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+import { getBearing } from "./ar-view";
+import { latLngToLocal, localToLatLng } from "@/lib/geo";
+
+describe("getBearing", () => {
+  test("returns 90 degrees when moving east", () => {
+    const bearing = getBearing(
+      { latitude: 0, longitude: 0 },
+      { latitude: 0, longitude: 1 },
+    );
+    expect(bearing).toBeCloseTo(90);
+  });
+
+  test("returns 0 degrees when moving north", () => {
+    const bearing = getBearing(
+      { latitude: 0, longitude: 0 },
+      { latitude: 1, longitude: 0 },
+    );
+    expect(bearing).toBeCloseTo(0);
+  });
+});
+
+describe("world-coordinate conversions", () => {
+  test("latLngToLocal and back produces original coordinates", () => {
+    const origin = { lat: 10, lng: 20 };
+    const target = { lat: 10.000008983, lng: 20.000008983 }; // ~1m NE
+    const local = latLngToLocal(origin, target);
+    const roundTrip = localToLatLng(origin, local);
+    expect(roundTrip.lat).toBeCloseTo(target.lat);
+    expect(roundTrip.lng).toBeCloseTo(target.lng);
+  });
+});


### PR DESCRIPTION
## Summary
- add frustum culling and distance-based level of detail to AR view
- export `getBearing` and cover it plus coordinate conversions with unit tests
- document manual AR testing steps for permissions and device compatibility

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b930abe8908321ac9c879a4734f69c