### PR TITLE
Dispose camera stream after AR permission

### DIFF
--- a/src/hooks/use-ar-mode.test.ts
+++ b/src/hooks/use-ar-mode.test.ts
@@ -3,10 +3,13 @@ import { renderHook } from '@testing-library/react'
 import { describe, expect, test, vi } from 'vitest'
 import { useARMode } from './use-ar-mode'
 import { useOrientation } from './use-orientation'
+import { trackEvent } from '@/lib/analytics'
 
 vi.mock('./use-orientation')
+vi.mock('@/lib/analytics')
 
 const mockedUseOrientation = useOrientation as any
+const mockedTrackEvent = trackEvent as any
 
 describe('useARMode', () => {
   test('activates when beta exceeds threshold', () => {
@@ -28,7 +31,12 @@ describe('useARMode', () => {
   })
 
   test('requests camera permission', async () => {
-    const cameraSpy = vi.fn().mockResolvedValue({})
+    const stopSpy = vi.fn()
+    const removeTrackSpy = vi.fn()
+    const cameraSpy = vi.fn().mockResolvedValue({
+      getTracks: () => [{ stop: stopSpy }],
+      removeTrack: removeTrackSpy
+    })
     ;(navigator as any).mediaDevices = { getUserMedia: cameraSpy }
     let granted = false
     mockedUseOrientation.mockImplementation(() => ({
@@ -43,6 +51,9 @@ describe('useARMode', () => {
     await result.current.requestPermission()
     rerender()
     expect(cameraSpy).toHaveBeenCalled()
+    expect(stopSpy).toHaveBeenCalled()
+    expect(removeTrackSpy).toHaveBeenCalled()
+    expect(mockedTrackEvent).toHaveBeenCalledWith('ar_permission_granted')
     expect(result.current.permissionGranted).toBe(true)
   })
 })

--- a/src/hooks/use-ar-mode.ts
+++ b/src/hooks/use-ar-mode.ts
@@ -33,8 +33,13 @@ export function useARMode(threshold: number = 60) {
       return false;
     }
     try {
-      await navigator.mediaDevices.getUserMedia({ video: true });
+      const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+      stream.getTracks().forEach((track) => {
+        track.stop();
+        stream.removeTrack(track);
+      });
       setCameraPermissionGranted(true);
+      trackEvent("ar_permission_granted");
       return true;
     } catch {
       setCameraPermissionGranted(false);


### PR DESCRIPTION
## Summary
- stop and dispose camera stream after getUserMedia to free resources
- track `ar_permission_granted` analytics event
- verify stream cleanup and analytics in hook tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9336c02708321aab8c07eb3ebc0fa