### PR TITLE
feat: stabilize ar mode activation

### DIFF
--- a/src/hooks/use-ar-mode.test.ts
+++ b/src/hooks/use-ar-mode.test.ts
@@ -30,6 +30,32 @@ describe('useARMode', () => {
     expect(result.current.isARActive).toBe(true)
   })
 
+  test('prevents flicker around threshold', () => {
+    mockedUseOrientation.mockReturnValue({
+      orientation: { alpha: 0, beta: 80, gamma: 0 },
+      permissionGranted: true,
+      requestPermission: vi.fn().mockResolvedValue(true)
+    })
+    const { result, rerender } = renderHook(() => useARMode(60, 5))
+    expect(result.current.isARActive).toBe(true)
+
+    mockedUseOrientation.mockReturnValue({
+      orientation: { alpha: 0, beta: 58, gamma: 0 },
+      permissionGranted: true,
+      requestPermission: vi.fn().mockResolvedValue(true)
+    })
+    rerender()
+    expect(result.current.isARActive).toBe(true)
+
+    mockedUseOrientation.mockReturnValue({
+      orientation: { alpha: 0, beta: 40, gamma: 0 },
+      permissionGranted: true,
+      requestPermission: vi.fn().mockResolvedValue(true)
+    })
+    rerender()
+    expect(result.current.isARActive).toBe(false)
+  })
+
   test('requests camera permission', async () => {
     const stopSpy = vi.fn()
     const removeTrackSpy = vi.fn()

--- a/src/hooks/use-ar-mode.ts
+++ b/src/hooks/use-ar-mode.ts
@@ -4,7 +4,7 @@ import { useEffect, useState } from "react";
 import { useOrientation } from "./use-orientation";
 import { trackEvent } from "@/lib/analytics";
 
-export function useARMode(threshold: number = 60) {
+export function useARMode(threshold: number = 60, hysteresis: number = 5) {
   const {
     orientation,
     permissionGranted: orientationGranted,
@@ -14,10 +14,12 @@ export function useARMode(threshold: number = 60) {
   const [isARActive, setIsARActive] = useState(false);
 
   useEffect(() => {
-    if (orientation.beta !== null) {
-      setIsARActive(orientation.beta > threshold);
-    }
-  }, [orientation.beta, threshold]);
+    const beta = orientation.beta;
+    if (beta === null) return;
+    setIsARActive((prev) =>
+      prev ? beta > threshold - hysteresis : beta > threshold
+    );
+  }, [orientation.beta, threshold, hysteresis]);
 
   const permissionGranted = orientationGranted && cameraPermissionGranted;
 


### PR DESCRIPTION
## Summary
- add hysteresis to AR mode threshold to avoid flicker when device pitch hovers around limit
- test AR mode hysteresis and ensure camera permission handling remains

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b93c326eec8321a59698670105abdb