### PR TITLE
Fix AR view not showing when device tilted upward

### DIFF
--- a/src/hooks/use-ar-mode.test.ts
+++ b/src/hooks/use-ar-mode.test.ts
@@ -42,6 +42,29 @@ describe('useARMode', () => {
     vi.useRealTimers()
   })
 
+  test('activates for negative beta values beyond threshold', () => {
+    vi.useFakeTimers()
+    mockedUseOrientation.mockReturnValue({
+      orientation: { alpha: 0, beta: -30, gamma: 0 },
+      permissionGranted: true,
+      requestPermission: vi.fn().mockResolvedValue(true)
+    })
+    const { result, rerender } = renderHook(() => useARMode(45))
+    expect(result.current.isARActive).toBe(false)
+
+    mockedUseOrientation.mockReturnValue({
+      orientation: { alpha: 0, beta: -80, gamma: 0 },
+      permissionGranted: true,
+      requestPermission: vi.fn().mockResolvedValue(true)
+    })
+    rerender()
+    act(() => {
+      vi.advanceTimersByTime(300)
+    })
+    expect(result.current.isARActive).toBe(true)
+    vi.useRealTimers()
+  })
+
   test('debounces deactivation when hovering near threshold', () => {
     vi.useFakeTimers()
     mockedUseOrientation.mockReturnValue({

--- a/src/hooks/use-ar-mode.ts
+++ b/src/hooks/use-ar-mode.ts
@@ -21,9 +21,10 @@ export function useARMode(
   useEffect(() => {
     const beta = orientation.beta;
     if (beta === null) return;
+    const absBeta = Math.abs(beta);
     const target = isARActive
-      ? beta > threshold - hysteresis
-      : beta > threshold;
+      ? absBeta > threshold - hysteresis
+      : absBeta > threshold;
 
     if (target === isARActive) {
       if (timeoutRef.current) {


### PR DESCRIPTION
## Summary
- handle negative device orientation values in AR activation logic
- test AR mode with negative beta tilt

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b955a957f88321ab2c326acf9d6ea7