### PR TITLE
Add onboarding overlay for primary controls

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -33,6 +33,7 @@ import { cn } from '@/lib/utils';
 import { NotificationsButton } from './notifications-button';
 import ARView from './ar-view';
 import { useARMode } from '@/hooks/use-ar-mode';
+import OnboardingOverlay from './onboarding-overlay';
 
 const DEFAULT_CENTER = { latitude: 34.052235, longitude: -118.243683 };
 const DEFAULT_ZOOM = 16;
@@ -320,6 +321,8 @@ function MapViewContent() {
             </Popup>
         )}
       </Map>
+
+      <OnboardingOverlay />
 
       {loading && (
         <div

--- a/src/components/onboarding-overlay.test.tsx
+++ b/src/components/onboarding-overlay.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent, cleanup } from '@testing-library/react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import OnboardingOverlay from './onboarding-overlay';
+
+describe('OnboardingOverlay', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shows overlay on first visit', () => {
+    const { getByTestId } = render(<OnboardingOverlay />);
+    expect(getByTestId('onboarding-overlay')).toBeTruthy();
+  });
+
+  it('hides overlay after dismissal and stores flag', () => {
+    const { getByTestId, queryByTestId } = render(<OnboardingOverlay />);
+    fireEvent.click(getByTestId('onboarding-overlay'));
+    expect(window.localStorage.getItem('onboardingSeen')).toBe('true');
+    expect(queryByTestId('onboarding-overlay')).toBeNull();
+  });
+
+  it('does not show overlay when already seen', () => {
+    window.localStorage.setItem('onboardingSeen', 'true');
+    const { queryByTestId } = render(<OnboardingOverlay />);
+    expect(queryByTestId('onboarding-overlay')).toBeNull();
+  });
+});

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+export default function OnboardingOverlay() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const seen = window.localStorage.getItem('onboardingSeen');
+      if (!seen) {
+        setVisible(true);
+      }
+    }
+  }, []);
+
+  const handleDismiss = () => {
+    setVisible(false);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem('onboardingSeen', 'true');
+    }
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div
+      data-testid="onboarding-overlay"
+      className="absolute inset-0 z-30"
+      onClick={handleDismiss}
+    >
+      <div className="absolute inset-0 bg-black/60" />
+
+      <div className="pointer-events-none">
+        <div className="absolute top-16 right-4 text-right">
+          <div className="bg-background/90 text-foreground text-xs px-2 py-1 rounded-md shadow">
+            Toggle AR
+          </div>
+        </div>
+        <div className="absolute bottom-40 right-20 text-right">
+          <div className="bg-background/90 text-foreground text-xs px-2 py-1 rounded-md shadow">
+            Center on your location
+          </div>
+        </div>
+        <div className="absolute bottom-24 right-20 text-right">
+          <div className="bg-background/90 text-foreground text-xs px-2 py-1 rounded-md shadow">
+            Create a note
+          </div>
+        </div>
+        <div className="absolute inset-0 flex items-center justify-center">
+          <div className="bg-background/90 text-foreground px-4 py-2 rounded-md shadow">
+            Tap anywhere to start
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- introduce OnboardingOverlay component shown on first visit
- highlight AR toggle, note creation, and location centering controls
- include unit tests for overlay behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97df73c7883218feda1d542638d89