### PR TITLE
feat: add skeleton loader for map view

### DIFF
--- a/src/components/map-skeleton.tsx
+++ b/src/components/map-skeleton.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Skeleton } from "./ui/skeleton";
+import { cn } from "@/lib/utils";
+
+interface MapSkeletonProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export function MapSkeleton({ className, ...props }: MapSkeletonProps) {
+  const markerPositions = [
+    { top: "30%", left: "40%" },
+    { top: "55%", left: "65%" },
+    { top: "70%", left: "25%" },
+  ];
+
+  return (
+    <div className={cn("bg-background", className)} {...props}>
+      <div className="grid h-full w-full grid-cols-4 gap-px">
+        {Array.from({ length: 16 }).map((_, i) => (
+          <Skeleton key={i} className="h-full w-full rounded-none" />
+        ))}
+      </div>
+      {markerPositions.map((pos, i) => (
+        <Skeleton
+          key={i}
+          className="absolute h-4 w-4 -translate-x-1/2 -translate-y-1/2 rounded-full"
+          style={{ top: pos.top, left: pos.left }}
+        />
+      ))}
+    </div>
+  );
+}
+
+export default MapSkeleton;

--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -120,7 +120,7 @@ describe('MapView', () => {
     expect(updatedMap.style.display).toBe('block');
   });
 
-  it('renders spinner while loading', () => {
+  it('renders skeleton while loading', () => {
     useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null });
     const { getByTestId } = render(<MapView />);
     expect(getByTestId('map-loading')).toBeTruthy();

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Map, { Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef, ViewState } from 'react-map-gl/maplibre';
-import { Plus, MapPin, Compass, LocateFixed, Loader2 } from 'lucide-react';
+import { Plus, MapPin, Compass, LocateFixed } from 'lucide-react';
 import { useLocation, Coordinates } from '@/hooks/use-location';
 import { useNotes } from '@/hooks/use-notes';
 import { useToast } from '@/hooks/use-toast';
@@ -33,6 +33,7 @@ import { cn } from '@/lib/utils';
 import { NotificationsButton } from './notifications-button';
 import ARView from './ar-view';
 import { useARMode } from '@/hooks/use-ar-mode';
+import { MapSkeleton } from './map-skeleton';
 
 const DEFAULT_CENTER = { latitude: 34.052235, longitude: -118.243683 };
 const DEFAULT_ZOOM = 16;
@@ -322,12 +323,10 @@ function MapViewContent() {
       </Map>
 
       {loading && (
-        <div
+        <MapSkeleton
           data-testid="map-loading"
-          className="absolute inset-0 z-20 flex items-center justify-center bg-background/50"
-        >
-          <Loader2 className="h-8 w-8 animate-spin" />
-        </div>
+          className="absolute inset-0 z-20"
+        />
       )}
 
       {!loading && notes.length === 0 && (
@@ -426,9 +425,9 @@ function MapViewContent() {
 }
 
 export default function MapView() {
-    return (
-        <React.Suspense fallback={<div>Loading...</div>}>
-            <MapViewContent />
-        </React.Suspense>
-    )
+  return (
+    <React.Suspense fallback={<MapSkeleton className="fixed inset-0 h-screen w-screen" />}>
+      <MapViewContent />
+    </React.Suspense>
+  );
 }


### PR DESCRIPTION
## Summary
- replace map view suspense fallback with full-screen skeleton loader
- show animated skeleton tiles and markers while notes load
- update map view tests for new loading UI

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97dfd3d74832184805f772f3099df