### PR TITLE
feat: add map loading skeleton

### DIFF
--- a/src/components/map-skeleton.tsx
+++ b/src/components/map-skeleton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Skeleton } from './ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface MapSkeletonProps {
+  className?: string;
+}
+
+export function MapSkeleton({ className }: MapSkeletonProps) {
+  return (
+    <div className={cn('relative h-full w-full bg-background', className)}>
+      <div className="grid h-full w-full grid-cols-2 grid-rows-2 gap-2 p-2">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-full w-full" />
+        ))}
+      </div>
+      <Skeleton className="absolute top-1/3 left-1/3 h-5 w-5 rounded-full" />
+      <Skeleton className="absolute top-2/3 left-1/2 h-6 w-6 rounded-full" />
+      <Skeleton className="absolute top-1/2 left-2/3 h-4 w-4 rounded-full" />
+    </div>
+  );
+}

--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -120,10 +120,11 @@ describe('MapView', () => {
     expect(updatedMap.style.display).toBe('block');
   });
 
-  it('renders spinner while loading', () => {
+  it('renders loader while loading', () => {
     useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null });
     const { getByTestId } = render(<MapView />);
-    expect(getByTestId('map-loading')).toBeTruthy();
+    const loader = getByTestId('map-loading');
+    expect(loader.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
   });
 
   it('shows message when no notes', () => {

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Map, { Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef, ViewState } from 'react-map-gl/maplibre';
-import { Plus, MapPin, Compass, LocateFixed, Loader2 } from 'lucide-react';
+import { Plus, MapPin, Compass, LocateFixed } from 'lucide-react';
 import { useLocation, Coordinates } from '@/hooks/use-location';
 import { useNotes } from '@/hooks/use-notes';
 import { useToast } from '@/hooks/use-toast';
@@ -34,6 +34,7 @@ import { NotificationsButton } from './notifications-button';
 import ARView from './ar-view';
 import { useARMode } from '@/hooks/use-ar-mode';
 import OnboardingOverlay from './onboarding-overlay';
+import { MapSkeleton } from './map-skeleton';
 
 const DEFAULT_CENTER = { latitude: 34.052235, longitude: -118.243683 };
 const DEFAULT_ZOOM = 16;
@@ -325,11 +326,8 @@ function MapViewContent() {
       <OnboardingOverlay />
 
       {loading && (
-        <div
-          data-testid="map-loading"
-          className="absolute inset-0 z-20 flex items-center justify-center bg-background/50"
-        >
-          <Loader2 className="h-8 w-8 animate-spin" />
+        <div data-testid="map-loading" className="absolute inset-0 z-20">
+          <MapSkeleton />
         </div>
       )}
 
@@ -430,7 +428,7 @@ function MapViewContent() {
 
 export default function MapView() {
     return (
-        <React.Suspense fallback={<div>Loading...</div>}>
+        <React.Suspense fallback={<MapSkeleton className="h-screen w-screen" />}>
             <MapViewContent />
         </React.Suspense>
     )


### PR DESCRIPTION
## Summary
- replace suspense fallback with full-screen map skeleton
- show animated tile and marker placeholders during map note fetches
- update test for new skeleton loader

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9852120688321a6c82b5c45ae1182