### PR TITLE
Mount ARView only after user enables AR

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -99,23 +99,24 @@ describe('MapView', () => {
   it('enters AR view when permission granted and enable AR clicked', async () => {
     const requestPermission = vi.fn().mockResolvedValue(true);
     useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission, arError: null, setArError: vi.fn() });
-    const { getAllByTestId, getByText, getByTestId } = render(<MapView />);
+    const { getAllByTestId, getByText, getByTestId, queryByTestId } = render(<MapView />);
     fireEvent.click(getByTestId('onboarding-overlay'));
     await waitFor(() => expect(() => getByTestId('onboarding-overlay')).toThrow());
     await act(async () => {
       fireEvent.click(getByText('Enable AR'));
     });
     await waitFor(() => expect(enterARHandler).toHaveBeenCalled());
+    await waitFor(() => expect(getByTestId('arview')).toBeTruthy());
     const maps = getAllByTestId('map');
     const map = maps[maps.length - 1] as HTMLDivElement;
     expect(map.style.display).toBe('none');
-    expect(getByTestId('arview').style.display).toBe('block');
+    expect(queryByTestId('arview')).toBeTruthy();
   });
 
   it('keeps map visible when AR permission denied', async () => {
     const requestPermission = vi.fn().mockResolvedValue(false);
     useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission, arError: null, setArError: vi.fn() });
-    const { getAllByTestId, getByText, getByTestId } = render(<MapView />);
+    const { getAllByTestId, getByText, getByTestId, queryByTestId } = render(<MapView />);
     fireEvent.click(getByTestId('onboarding-overlay'));
     await waitFor(() => expect(() => getByTestId('onboarding-overlay')).toThrow());
     await act(async () => {
@@ -125,22 +126,22 @@ describe('MapView', () => {
       const maps = getAllByTestId('map');
       const map = maps[maps.length - 1] as HTMLDivElement;
       expect(map.style.display).toBe('block');
-      expect(getByTestId('arview').style.display).toBe('none');
+      expect(queryByTestId('arview')).toBeNull();
     });
   });
 
   it('shows map after returning from AR view', async () => {
     const requestPermission = vi.fn().mockResolvedValue(true);
     useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission, arError: null, setArError: vi.fn() });
-    const { getAllByTestId, getByText, getByTestId } = render(<MapView />);
+    const { getAllByTestId, getByText, getByTestId, queryByTestId } = render(<MapView />);
     fireEvent.click(getByTestId('onboarding-overlay'));
     await waitFor(() => expect(() => getByTestId('onboarding-overlay')).toThrow());
     await act(async () => {
       fireEvent.click(getByText('Enable AR'));
     });
-    await waitFor(() => expect(getByTestId('arview').style.display).toBe('block'));
+    await waitFor(() => expect(getByTestId('arview')).toBeTruthy());
     fireEvent.click(getByTestId('arview'));
-    await waitFor(() => expect(getByTestId('arview').style.display).toBe('none'));
+    await waitFor(() => expect(queryByTestId('arview')).toBeNull());
     const maps = getAllByTestId('map');
     const map = maps[maps.length - 1] as HTMLDivElement;
     expect(map.style.display).toBe('block');

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -226,7 +226,6 @@ function MapViewContent() {
     const hasPermission = await requestARPermission();
     if (hasPermission) {
       setARViewVisible(true);
-      await arViewRef.current?.enterAR();
     }
   };
 
@@ -254,6 +253,13 @@ function MapViewContent() {
   const mapStyleUrl = theme === 'dark' 
     ? "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
     : "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json";
+
+  useEffect(() => {
+    if (isARViewVisible) {
+      arViewRef.current?.enterAR();
+    }
+  }, [isARViewVisible]);
+
   
 
   if (permissionState !== 'granted' && permissionState !== 'prompt') {
@@ -270,14 +276,15 @@ function MapViewContent() {
 
   return (
     <div className="h-screen w-screen relative">
-      <ARView
-        ref={arViewRef}
-        notes={notes}
-        onSelectNote={handleMarkerClick}
-        onReturnToMap={() => setARViewVisible(false)}
-        onCreateNote={handleARCreateNote}
-        style={{ display: isARViewVisible ? 'block' : 'none' }}
-      />
+      {isARViewVisible && (
+        <ARView
+          ref={arViewRef}
+          notes={notes}
+          onSelectNote={handleMarkerClick}
+          onReturnToMap={() => setARViewVisible(false)}
+          onCreateNote={handleARCreateNote}
+        />
+      )}
       <Map
         ref={mapRef}
         {...viewState}


### PR DESCRIPTION
## Summary
- Mount `ARView` only when AR mode is activated
- Trigger AR session via effect once the view is visible
- Update MapView tests for conditional AR rendering

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9bb1fe0548321903b896f514606ff