### PR TITLE
fix: correct latitude conversion in map view distance calc

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -106,7 +106,7 @@ function MapViewContent() {
       const dLat = toRad(coords2.latitude - coords1.latitude);
       const dLon = toRad(coords2.longitude - coords1.longitude);
       const lat1 = toRad(coords1.latitude);
-      const lat2 = toRad(coords1.latitude);
+      const lat2 = toRad(coords2.latitude);
     
       const a =
         Math.sin(dLat / 2) * Math.sin(dLat / 2) +


### PR DESCRIPTION
## Summary
- fix getDistance calculation by converting second latitude from coords2

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d54b6b50832188e2d6566e7ec3ab