### PR TITLE
refactor: type report note updates

### DIFF
--- a/src/ai/flows/report-note-flow.ts
+++ b/src/ai/flows/report-note-flow.ts
@@ -39,7 +39,7 @@ const reportNoteFlow = ai.defineFlow(
         const noteSnap = await t.get(noteRef);
         const current = noteSnap.data()?.reportCount ?? 0;
         const newCount = current + 1;
-        const updates: any = { reportCount: newCount };
+        const updates: { reportCount: number; visibility?: 'unlisted' } = { reportCount: newCount };
         if (newCount >= REPORT_THRESHOLD) {
           updates.visibility = 'unlisted';
         }


### PR DESCRIPTION
## Summary
- type transaction update object in report note flow

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d54e1a548321bae22679b72eef82