### PR TITLE
chore: type server timestamp

### DIFF
--- a/src/components/create-note-form.tsx
+++ b/src/components/create-note-form.tsx
@@ -80,7 +80,9 @@ export default function CreateNoteForm({
       const pseudonym = await getOrCreatePseudonym(user.uid);
       const geohash = geohashForLocation([userLocation.latitude, userLocation.longitude]);
 
-      const newNote: Omit<Note, "id" | "createdAt"> & { createdAt: any } = {
+      const newNote: Omit<Note, "id" | "createdAt"> & {
+        createdAt: ReturnType<typeof serverTimestamp>;
+      } = {
         text,
         lat: userLocation.latitude,
         lng: userLocation.longitude,


### PR DESCRIPTION
## Summary
- type Firestore server timestamp when creating a note

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d555e51483219d14e20b215c2fb4