### PR TITLE
refactor: type limited drop timestamp

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,7 +21,10 @@ export interface Note {
   revealAngleDeg: number;
   teaser?: string | null;
   peekable: boolean;
-  limitedDrop?: { enabled: boolean; endsAt?: any } | null;
+  limitedDrop?: {
+    enabled: boolean;
+    endsAt?: { seconds: number; nanoseconds: number } | null;
+  } | null;
   dmAllowed: boolean;
   reportCount?: number;
 }


### PR DESCRIPTION
## Summary
- type `limitedDrop.endsAt` with `{ seconds: number; nanoseconds: number }`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d578b2bc8321aa3fa4134358d57b