### PR TITLE
chore: tighten analytics event typing

### DIFF
--- a/src/hooks/use-ar-mode.test.ts
+++ b/src/hooks/use-ar-mode.test.ts
@@ -8,8 +8,8 @@ import { trackEvent } from '@/lib/analytics';
 vi.mock('./use-orientation');
 vi.mock('@/lib/analytics');
 
-const mockedUseOrientation = useOrientation as any;
-const mockedTrackEvent = trackEvent as any;
+const mockedUseOrientation = vi.mocked(useOrientation);
+const mockedTrackEvent = vi.mocked(trackEvent);
 
 describe('useARMode', () => {
   beforeEach(() => {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,7 +3,26 @@ import { app, isFirebaseConfigured } from './firebase';
 
 let analytics: Analytics | undefined;
 
-export function trackEvent(event: string, params?: Record<string, any>) {
+type ARLaunchFailedReason =
+  | 'xr_unsupported'
+  | 'xr_check_failed'
+  | 'orientation_denied'
+  | 'media_devices_unsupported'
+  | 'camera_denied';
+
+type ARPermissionType = 'orientation' | 'camera';
+
+export function trackEvent(
+  event: 'ar_launch_failed',
+  params: { reason: ARLaunchFailedReason },
+): void;
+export function trackEvent(
+  event: 'ar_permission_denied',
+  params: { type: ARPermissionType },
+): void;
+export function trackEvent(event: 'ar_permission_granted'): void;
+export function trackEvent(event: string, params?: Record<string, unknown>): void;
+export function trackEvent(event: string, params?: Record<string, unknown>) {
   if (typeof window === 'undefined' || !isFirebaseConfigured) return;
   if (!analytics) {
     try {


### PR DESCRIPTION
## Summary
- enforce explicit analytics event param types
- use typed mocks for analytics hook tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d57a6bac832192fcff92a3fddce0