### PR TITLE
Validate report threshold parsing

### DIFF
--- a/src/lib/reporting.test.ts
+++ b/src/lib/reporting.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, afterEach } from 'vitest';
 import { calculateReportUpdate } from './reporting';
 
 describe('calculateReportUpdate', () => {
@@ -10,5 +10,36 @@ describe('calculateReportUpdate', () => {
   it('hides when threshold reached', () => {
     const res = calculateReportUpdate(2, 3);
     expect(res).toEqual({ newCount: 3, hide: true });
+  });
+});
+
+describe('REPORT_THRESHOLD', () => {
+  const original = process.env.NEXT_PUBLIC_REPORT_THRESHOLD;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.NEXT_PUBLIC_REPORT_THRESHOLD;
+    } else {
+      process.env.NEXT_PUBLIC_REPORT_THRESHOLD = original;
+    }
+    vi.resetModules();
+  });
+
+  it('defaults to 3 when env var missing', async () => {
+    delete process.env.NEXT_PUBLIC_REPORT_THRESHOLD;
+    const { REPORT_THRESHOLD } = await import('./reporting');
+    expect(REPORT_THRESHOLD).toBe(3);
+  });
+
+  it('parses env var when valid', async () => {
+    process.env.NEXT_PUBLIC_REPORT_THRESHOLD = '5';
+    const { REPORT_THRESHOLD } = await import('./reporting');
+    expect(REPORT_THRESHOLD).toBe(5);
+  });
+
+  it('falls back to 3 on invalid value', async () => {
+    process.env.NEXT_PUBLIC_REPORT_THRESHOLD = 'foo';
+    const { REPORT_THRESHOLD } = await import('./reporting');
+    expect(REPORT_THRESHOLD).toBe(3);
   });
 });

--- a/src/lib/reporting.ts
+++ b/src/lib/reporting.ts
@@ -1,4 +1,6 @@
-export const REPORT_THRESHOLD = Number(process.env.NEXT_PUBLIC_REPORT_THRESHOLD ?? 3);
+const rawThreshold = process.env.NEXT_PUBLIC_REPORT_THRESHOLD;
+const parsedThreshold = Number.parseInt(rawThreshold ?? '', 10);
+export const REPORT_THRESHOLD = Number.isNaN(parsedThreshold) ? 3 : parsedThreshold;
 
 export function calculateReportUpdate(current: number, threshold: number = REPORT_THRESHOLD) {
   const newCount = current + 1;


### PR DESCRIPTION
## Summary
- robustly parse report threshold from environment and default to 3 when invalid
- add tests for report threshold parsing

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError importScripts is not defined)*
- `npx vitest run src/lib/reporting.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b9d55c86c8832182365e145333f8a5