### PR TITLE
Avoid WebGL context churn in AR view

### DIFF
--- a/src/components/ar-view.tsx
+++ b/src/components/ar-view.tsx
@@ -46,6 +46,7 @@ const ARView = forwardRef<ARViewHandle, ARViewProps>(
   const { location } = useLocation();
   const locationRef = useRef(location);
   const onCreateNoteRef = useRef(onCreateNote);
+  const onSelectNoteRef = useRef(onSelectNote);
 
   useEffect(() => {
     locationRef.current = location;
@@ -54,6 +55,10 @@ const ARView = forwardRef<ARViewHandle, ARViewProps>(
   useEffect(() => {
     onCreateNoteRef.current = onCreateNote;
   }, [onCreateNote]);
+
+  useEffect(() => {
+    onSelectNoteRef.current = onSelectNote;
+  }, [onSelectNote]);
 
   // initialize three.js and WebXR renderer
   useEffect(() => {
@@ -180,7 +185,7 @@ const ARView = forwardRef<ARViewHandle, ARViewProps>(
         }
         const note = obj?.userData.note as GhostNote | undefined;
         if (note) {
-          onSelectNote(note);
+          onSelectNoteRef.current(note);
         }
       }
     };
@@ -199,7 +204,7 @@ const ARView = forwardRef<ARViewHandle, ARViewProps>(
       sceneRef.current = undefined;
       cameraRef.current = undefined;
     };
-  }, [onSelectNote]);
+  }, []);
 
   // create note meshes when notes change
   useEffect(() => {


### PR DESCRIPTION
## Summary
- keep latest note selection handler in ref
- initialize Three.js renderer only once

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: ReferenceError: importScripts is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ee4f4df08321afc81698f39aafd4