### PR TITLE
feat: replace logo with custom svg

### DIFF
--- a/src/components/ui/logo.tsx
+++ b/src/components/ui/logo.tsx
@@ -1,9 +1,28 @@
-import { MapPin } from "lucide-react";
-
 export function Logo({ className }: { className?: string }) {
   return (
     <div className={`flex items-center gap-2 text-xl font-bold font-headline ${className}`}>
-      <MapPin className="h-6 w-6 text-primary" />
+      <svg
+        className="h-6 w-6"
+        viewBox="0 0 64 64"
+        xmlns="http://www.w3.org/2000/svg"
+        aria-hidden="true"
+        focusable="false"
+      >
+        <path
+          fill="#2F80FF"
+          d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"
+        />
+        <rect
+          fill="#FFC83D"
+          x="23.5"
+          y="22.5"
+          rx="2.5"
+          ry="2.5"
+          width="17"
+          height="17"
+        />
+        <path fill="#FFD766" d="M40.5 22.5h-6l6 6z" />
+      </svg>
       <span>NoteDrop</span>
     </div>
   );

--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -46,6 +46,11 @@ function setupSW() {
     self: (globalThis as any).self,
     caches: (globalThis as any).caches,
     fetch: (...args: any[]) => (globalThis as any).fetch(...args),
+    importScripts: () => undefined,
+    firebase: {
+      initializeApp: () => ({}),
+      messaging: () => ({ onBackgroundMessage: vi.fn() }),
+    },
     URL,
     Request,
     Response,


### PR DESCRIPTION
## Summary
- use custom SVG drop icon for in-app logo
- add fetch caching to service worker and stub missing APIs in tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f2ef69f4832188b17cadcc1cd9a0