### PR TITLE
Add extended NoteDrop SVG sprite and icons

### DIFF
--- a/public/ui/README.md
+++ b/public/ui/README.md
@@ -1,0 +1,18 @@
+# NoteDrop UI SVGs (Extended)
+Use the sprite (`notedrop-ui-sprite-extended.svg`) inline at the root of your HTML (or inject via JS), then reference icons with:
+```html
+<svg width="24" height="24" viewBox="0 0 64 64"><use href="#nd-pin-default"/></svg>
+```
+Symbols included:
+
+Pins: nd-pin-default • nd-pin-ghost • nd-pin-limited • nd-pin-lowtrust • nd-pin-selected • nd-pin-reported
+
+Map/AR: nd-cluster • nd-compass • nd-sight-arc • nd-lock • nd-camera • nd-countdown
+
+Actions: nd-heart • nd-bookmark • nd-reply • nd-share • nd-flag
+
+System: nd-user • nd-settings • nd-accessibility • nd-ar • nd-location-on • nd-location-off
+
+Badges: nd-badge-starter • nd-badge-verified
+
+Colors are baked from the brand palette. You can override fills with CSS if you embed the sprite in the DOM.

--- a/public/ui/accessibility.svg
+++ b/public/ui/accessibility.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-accessibility"/>
+</svg>

--- a/public/ui/ar.svg
+++ b/public/ui/ar.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-ar"/>
+</svg>

--- a/public/ui/badge-starter.svg
+++ b/public/ui/badge-starter.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-badge-starter"/>
+</svg>

--- a/public/ui/badge-verified.svg
+++ b/public/ui/badge-verified.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-badge-verified"/>
+</svg>

--- a/public/ui/bookmark.svg
+++ b/public/ui/bookmark.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-bookmark"/>
+</svg>

--- a/public/ui/camera.svg
+++ b/public/ui/camera.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-camera"/>
+</svg>

--- a/public/ui/cluster.svg
+++ b/public/ui/cluster.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-cluster"/>
+</svg>

--- a/public/ui/compass.svg
+++ b/public/ui/compass.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-compass"/>
+</svg>

--- a/public/ui/countdown.svg
+++ b/public/ui/countdown.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-countdown"/>
+</svg>

--- a/public/ui/flag.svg
+++ b/public/ui/flag.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-flag"/>
+</svg>

--- a/public/ui/heart.svg
+++ b/public/ui/heart.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-heart"/>
+</svg>

--- a/public/ui/location-off.svg
+++ b/public/ui/location-off.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-location-off"/>
+</svg>

--- a/public/ui/location-on.svg
+++ b/public/ui/location-on.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-location-on"/>
+</svg>

--- a/public/ui/lock.svg
+++ b/public/ui/lock.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-lock"/>
+</svg>

--- a/public/ui/notedrop-ui-sprite-extended.svg
+++ b/public/ui/notedrop-ui-sprite-extended.svg
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>

--- a/public/ui/pin-default.svg
+++ b/public/ui/pin-default.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-pin-default"/>
+</svg>

--- a/public/ui/pin-ghost.svg
+++ b/public/ui/pin-ghost.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-pin-ghost"/>
+</svg>

--- a/public/ui/pin-limited.svg
+++ b/public/ui/pin-limited.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-pin-limited"/>
+</svg>

--- a/public/ui/pin-lowtrust.svg
+++ b/public/ui/pin-lowtrust.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-pin-lowtrust"/>
+</svg>

--- a/public/ui/pin-reported.svg
+++ b/public/ui/pin-reported.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-pin-reported"/>
+</svg>

--- a/public/ui/pin-selected.svg
+++ b/public/ui/pin-selected.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-pin-selected"/>
+</svg>

--- a/public/ui/reply.svg
+++ b/public/ui/reply.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-reply"/>
+</svg>

--- a/public/ui/settings.svg
+++ b/public/ui/settings.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-settings"/>
+</svg>

--- a/public/ui/share.svg
+++ b/public/ui/share.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-share"/>
+</svg>

--- a/public/ui/sight-arc.svg
+++ b/public/ui/sight-arc.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-sight-arc"/>
+</svg>

--- a/public/ui/user.svg
+++ b/public/ui/user.svg
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="128" height="128">
+  <?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" style="display:none">
+  <defs>
+    <style>
+      :root {
+        --nd-blue:#2F80FF; --nd-yellow:#FFC83D; --nd-amber:#FFB020;
+        --nd-slate:#94A3B8; --nd-navy:#0F172A; --nd-white:#FFFFFF;
+        --nd-danger:#EF4444; --nd-success:#16A34A;
+      }
+    </style>
+  </defs>
+
+  <!-- ==== PINS ==== -->
+  <!-- Default: solid blue pin + sticky note -->
+  <symbol id="nd-pin-default" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Ghost: hollow outline, no note -->
+  <symbol id="nd-pin-ghost" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 58c-6-9-18-19-18-30 0-10 8-18 18-18s18 8 18 18c0 11-12 21-18 30z" opacity="0.2"/>
+    <circle cx="32" cy="29" r="11" fill="none" stroke="#2F80FF" stroke-width="3" opacity="0.6"/>
+  </symbol>
+
+  <!-- Limited: amber body -->
+  <symbol id="nd-pin-limited" viewBox="0 0 64 64">
+    <path fill="#FFB020" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Low-trust: slate body -->
+  <symbol id="nd-pin-lowtrust" viewBox="0 0 64 64">
+    <path fill="#94A3B8" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Selected: blue with white ring -->
+  <symbol id="nd-pin-selected" viewBox="0 0 64 64">
+    <path fill="#2F80FF" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <circle cx="32" cy="29" r="18" fill="none" stroke="#FFFFFF" stroke-width="3" opacity="0.9"/>
+    <rect fill="#FFC83D" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFD766" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- Reported/Error: danger red -->
+  <symbol id="nd-pin-reported" viewBox="0 0 64 64">
+    <path fill="#EF4444" d="M32 60c-6.8-8.8-20-19.2-20-32C12 15.2 20.2 7 32 7s20 8.2 20 21c0 12.8-13.2 23.2-20 32z"/>
+    <rect fill="#FFFFFF" x="23.5" y="22.5" rx="2.5" ry="2.5" width="17" height="17"/>
+    <path fill="#FFFFFF" d="M40.5 22.5h-6l6 6z"/>
+  </symbol>
+
+  <!-- ==== MAP/AR HELPERS ==== -->
+  <symbol id="nd-cluster" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="22" fill="#FFFFFF" opacity="0.18"/>
+  </symbol>
+
+  <symbol id="nd-compass" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFFFFF" stroke="#0F172A" stroke-width="2"/>
+    <path d="M32 10l8 18-8 4-8-4z" fill="#2F80FF"/>
+    <circle cx="32" cy="32" r="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-sight-arc" viewBox="0 0 64 64">
+    <path d="M6 32a26 26 0 0 1 52 0" fill="none" stroke="#2F80FF" stroke-width="4" stroke-linecap="round"/>
+    <path d="M16 32a16 16 0 0 1 32 0" fill="none" stroke="#FFB020" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-lock" viewBox="0 0 64 64">
+    <rect x="14" y="28" width="36" height="24" rx="6" fill="#0F172A"/>
+    <path d="M20 28v-6c0-7 5-12 12-12s12 5 12 12v6h-6v-6c0-3.3-2.7-6-6-6s-6 2.7-6 6v6z" fill="#0F172A"/>
+    <circle cx="32" cy="40" r="4" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-camera" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="30" rx="6" fill="#0F172A"/>
+    <circle cx="32" cy="33" r="9" fill="#FFFFFF"/>
+    <rect x="14" y="12" width="12" height="10" rx="3" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-countdown" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#FFB020"/>
+    <path d="M32 16v16l10 6" stroke="#0F172A" stroke-width="4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <!-- ==== UI ACTIONS ==== -->
+  <symbol id="nd-heart" viewBox="0 0 64 64">
+    <path d="M32 54s-18-11.4-22-22.3C7.8 26.5 12.2 20 19.3 20c4.7 0 8.1 2.6 10.7 5.8C32.6 22.6 36 20 40.7 20 47.8 20 52.2 26.5 54 31.7 50 42.6 32 54 32 54z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-bookmark" viewBox="0 0 64 64">
+    <path d="M18 10h28a4 4 0 0 1 4 4v40l-18-9-18 9V14a4 4 0 0 1 4-4z" fill="#2F80FF"/>
+  </symbol>
+
+  <symbol id="nd-reply" viewBox="0 0 64 64">
+    <path d="M12 30l16-12v8h12c8.8 0 16 7.2 16 16v4c-3-4-8-8-16-8H28v8L12 34z" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-share" viewBox="0 0 64 64">
+    <circle cx="20" cy="36" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="22" r="6" fill="#0F172A"/>
+    <circle cx="44" cy="46" r="6" fill="#0F172A"/>
+    <path d="M24 34l16-10M24 38l16 8" stroke="#0F172A" stroke-width="3" fill="none" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-flag" viewBox="0 0 64 64">
+    <path d="M14 10v44" stroke="#0F172A" stroke-width="4"/>
+    <path d="M18 12h28l-6 8 6 8H18z" fill="#EF4444"/>
+  </symbol>
+
+  <symbol id="nd-user" viewBox="0 0 64 64">
+    <circle cx="32" cy="24" r="10" fill="#0F172A"/>
+    <rect x="16" y="36" width="32" height="16" rx="8" fill="#0F172A"/>
+  </symbol>
+
+  <symbol id="nd-settings" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="6" fill="#0F172A"/>
+    <path d="M32 14l4 4 6-2 4 6-4 4 2 6-6 4-4-4-6 2-4-6 4-4-2-6 6-4z" fill="none" stroke="#0F172A" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
+
+  <symbol id="nd-accessibility" viewBox="0 0 64 64">
+    <circle cx="32" cy="12" r="6" fill="#0F172A"/>
+    <path d="M14 26h36M32 18v28M22 34l-8 22M42 34l8 22" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <symbol id="nd-ar" viewBox="0 0 64 64">
+    <rect x="8" y="18" width="48" height="28" rx="6" fill="#0F172A"/>
+    <path d="M26 26l6-4 6 4v8l-6 4-6-4z" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-on" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#16A34A"/>
+    <circle cx="32" cy="28" r="8" fill="#FFFFFF"/>
+  </symbol>
+
+  <symbol id="nd-location-off" viewBox="0 0 64 64">
+    <path d="M32 58c-10-12-18-21-18-30a18 18 0 1 1 36 0c0 9-8 18-18 30z" fill="#94A3B8"/>
+    <path d="M18 18l28 28" stroke="#EF4444" stroke-width="4" stroke-linecap="round"/>
+  </symbol>
+
+  <!-- ==== BADGES ==== -->
+  <symbol id="nd-badge-starter" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M32 16l5.5 10.8 12 1.8-8.7 8.4 2.1 11.9-10.9-5.7-10.9 5.7 2.1-11.9-8.7-8.4 12-1.8z" fill="#FFC83D"/>
+  </symbol>
+
+  <symbol id="nd-badge-verified" viewBox="0 0 64 64">
+    <circle cx="32" cy="32" r="26" fill="#2F80FF"/>
+    <path d="M26 34l-5-5-4 4 9 9 16-16-4-4z" fill="#FFFFFF"/>
+  </symbol>
+</svg>
+  <use href="#nd-user"/>
+</svg>


### PR DESCRIPTION
## Summary
- add extended NoteDrop UI SVG sprite with color palette and 25 icon symbols
- export each icon as standalone SVG for easy use
- document usage and available symbols in README

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f55895c08321830202c0e53dc237