### PR TITLE
feat: integrate custom svg icons

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import 'maplibre-gl/dist/maplibre-gl.css';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Pwa } from '@/components/pwa';
 import { SettingsProvider } from '@/hooks/use-settings';
+import { NdSprite } from '@/components/ui/nd-sprite';
 
 export const metadata: Metadata = {
   title: 'NoteDrop: Location-Based Notes',
@@ -40,6 +41,7 @@ export default function RootLayout({
         <link href="https://fonts.googleapis.com/css2?family=PT+Sans:wght@400;700&family=Source+Code+Pro:wght@400;700&display=swap" rel="stylesheet" />
       </head>
       <body className={cn('font-body antialiased', 'min-h-screen bg-background')}>
+        <NdSprite />
         <ThemeProvider
           attribute="class"
           defaultTheme="system"

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Map, { Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef, ViewState } from 'react-map-gl/maplibre';
-import { Plus, MapPin, Compass, LocateFixed, AlertTriangle, Camera } from 'lucide-react';
+import { Plus, Compass, LocateFixed, AlertTriangle } from 'lucide-react';
 import { useLocation, Coordinates } from '@/hooks/use-location';
 import { useNotes } from '@/hooks/use-notes';
 import { useToast } from '@/hooks/use-toast';
@@ -35,6 +35,7 @@ import ARView, { ARViewHandle } from './ar-view';
 import { useARMode } from '@/hooks/use-ar-mode';
 import OnboardingOverlay from './onboarding-overlay';
 import { MapSkeleton } from './map-skeleton';
+import { NdIcon } from './ui/nd-icon';
 
 const DEFAULT_CENTER = { latitude: 34.052235, longitude: -118.243683 };
 const DEFAULT_ZOOM = 16;
@@ -304,12 +305,13 @@ function MapViewContent() {
             return (
                 <Marker key={note.id} longitude={note.lng} latitude={note.lat} onClick={() => handleMarkerClick(note)}>
                     <button className="transform hover:scale-110 transition-transform relative">
-                        <MapPin className={cn('drop-shadow-lg', 
-                            sizeClass,
-                            isHot ? 'text-accent animate-flame-flicker' : 
-                            note.id === revealedNoteId ? 'text-accent' : 
-                            note.type === 'photo' ? 'text-secondary-foreground/70' : 'text-primary/70'
-                        )} fill="currentColor" />
+                        <NdIcon
+                            name={note.id === revealedNoteId ? 'pin-selected' : 'pin-default'}
+                            className={cn('drop-shadow-lg',
+                                sizeClass,
+                                isHot && 'animate-flame-flicker'
+                            )}
+                        />
                     </button>
                 </Marker>
             );
@@ -358,7 +360,7 @@ function MapViewContent() {
             <Logo />
             <div className="flex items-center gap-2 bg-background/80 p-1 rounded-full">
                 <Button onClick={handleEnableAR} size="sm" variant="secondary">
-                  <Camera className="mr-2" />
+                  <NdIcon name="camera" className="mr-2 h-4 w-4" />
                   Enable AR
                 </Button>
                 {permissionState === 'prompt' && (

--- a/src/components/ui/nd-icon.test.tsx
+++ b/src/components/ui/nd-icon.test.tsx
@@ -1,0 +1,16 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { NdIcon } from "./nd-icon";
+
+describe("NdIcon", () => {
+  it("references the correct symbol", () => {
+    const { container } = render(<NdIcon name="camera" />);
+    const use = container.querySelector("use");
+    expect(use?.getAttribute("href")).toBe("#nd-camera");
+  });
+});
+

--- a/src/components/ui/nd-icon.tsx
+++ b/src/components/ui/nd-icon.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+export interface NdIconProps extends React.SVGAttributes<SVGSVGElement> {
+  name: string;
+}
+
+export function NdIcon({ name, className, ...props }: NdIconProps) {
+  return (
+    <svg
+      {...props}
+      className={cn("inline-block", className)}
+      aria-hidden="true"
+    >
+      <use href={`#nd-${name}`} />
+    </svg>
+  );
+}
+

--- a/src/components/ui/nd-sprite.tsx
+++ b/src/components/ui/nd-sprite.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import * as React from "react";
+
+export function NdSprite() {
+  const [sprite, setSprite] = React.useState("");
+
+  React.useEffect(() => {
+    fetch("/ui/notedrop-ui-sprite-extended.svg")
+      .then((res) => res.text())
+      .then(setSprite)
+      .catch(() => {});
+  }, []);
+
+  if (!sprite) {
+    return null;
+  }
+
+  return (
+    <div
+      className="hidden"
+      aria-hidden="true"
+      dangerouslySetInnerHTML={{ __html: sprite }}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- inject NoteDrop SVG sprite and create NdIcon component
- replace lucide icons with sprite-based icons in map view
- test NdIcon symbol reference

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9f6a59e0c8321bc590470a1de1d47