### PR TITLE
feat: apply hand-drawn font and improve typography

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,7 +3,9 @@
 @tailwind utilities;
 
 body {
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-hand), cursive;
+  font-size: 1.125rem;
+  line-height: 1.6;
 }
 
 @layer base {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import { ThemeProvider } from '@/components/theme-provider';
 import { Pwa } from '@/components/pwa';
 import { SettingsProvider } from '@/hooks/use-settings';
 import { NdSprite } from '@/components/ui/nd-sprite';
+import { Patrick_Hand } from 'next/font/google';
 
 export const metadata: Metadata = {
   title: 'NoteDrop: Location-Based Notes',
@@ -33,13 +34,18 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const patrickHand = Patrick_Hand({
+    subsets: ['latin'],
+    weight: '400',
+    variable: '--font-hand',
+    display: 'swap',
+  });
   return (
-    <html lang="en" suppressHydrationWarning>
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
-        <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Lexend:wght@400;500;700&display=swap" rel="stylesheet" />
-      </head>
+    <html
+      lang="en"
+      suppressHydrationWarning
+      className={patrickHand.variable}
+    >
       <body className={cn('font-body antialiased', 'min-h-screen bg-background')}>
         <NdSprite />
         <ThemeProvider

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -268,7 +268,7 @@ export default function ProfilePage() {
                     <p className="text-muted-foreground">
                         {user?.isAnonymous ? "Anonymous User" : user?.email}
                     </p>
-                    {!user?.isAnonymous && (
+                    {user && !user.isAnonymous && (
                         <div className="mt-2">
                              <UpdateProfileForm uid={user.uid} currentDisplayName={displayName} />
                         </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -18,9 +18,14 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        body: ['Inter', 'sans-serif'],
-        headline: ['Lexend', 'sans-serif'],
+        body: ['var(--font-hand)', 'cursive'],
+        headline: ['var(--font-hand)', 'cursive'],
         code: ['Source Code Pro', 'monospace'],
+      },
+      fontSize: {
+        sm: ['1rem', { lineHeight: '1.5rem' }],
+        base: ['1.125rem', { lineHeight: '1.75rem' }],
+        lg: ['1.25rem', { lineHeight: '1.75rem' }],
       },
       colors: {
         background: 'hsl(var(--background))',


### PR DESCRIPTION
## Summary
- replace global fonts with Patrick Hand using Next.js font loader
- enlarge base font sizes and line heights for better legibility
- handle nullable user in profile page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: MapView enters AR view and use-notes error handling)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8f700944832187f1735d04c58d0d