### PR TITLE
feat: add wobbly borders to UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.54.2",
         "react-map-gl": "^7.1.7",
+        "react-rough-notation": "^1.0.5",
         "recharts": "^2.15.1",
         "tailwind-merge": "^3.0.1",
         "tailwindcss-animate": "^1.0.7",
@@ -15444,6 +15445,19 @@
         }
       }
     },
+    "node_modules/react-rough-notation": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/react-rough-notation/-/react-rough-notation-1.0.5.tgz",
+      "integrity": "sha512-TTDnw1Qn96PwitGsBsjNh4911+o26Vivj/dhHbsHHhN6lDgkQsFhv1X/eOnCjHA2EOyDE5JBQ1HEZ1yW8sCmKA==",
+      "license": "MIT",
+      "dependencies": {
+        "rough-notation": "^0.5.1"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
     "node_modules/react-smooth": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/react-smooth/-/react-smooth-4.0.4.tgz",
@@ -15846,6 +15860,12 @@
         "@rollup/rollup-win32-x64-msvc": "4.50.0",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rough-notation": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/rough-notation/-/rough-notation-0.5.1.tgz",
+      "integrity": "sha512-ITHofTzm13cWFVfoGsh/4c/k2Mg8geKgBCwex71UZLnNuw403tCRjYPQ68jSAd37DMbZIePXPjDgY0XdZi9HPw==",
+      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.54.2",
     "react-map-gl": "^7.1.7",
+    "react-rough-notation": "^1.0.5",
     "recharts": "^2.15.1",
     "tailwind-merge": "^3.0.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -268,7 +268,7 @@ export default function ProfilePage() {
                     <p className="text-muted-foreground">
                         {user?.isAnonymous ? "Anonymous User" : user?.email}
                     </p>
-                    {!user?.isAnonymous && (
+                    {user && !user.isAnonymous && (
                         <div className="mt-2">
                              <UpdateProfileForm uid={user.uid} currentDisplayName={displayName} />
                         </div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,8 +1,11 @@
+"use client"
+
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"
+import { WobblyWrapper } from "./wobbly-wrapper"
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
@@ -43,11 +46,13 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
     return (
-      <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
-        ref={ref}
-        {...props}
-      />
+      <WobblyWrapper>
+        <Comp
+          className={cn(buttonVariants({ variant, size, className }))}
+          ref={ref}
+          {...props}
+        />
+      </WobblyWrapper>
     )
   }
 )

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,19 +1,24 @@
+"use client"
+
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { WobblyWrapper } from "./wobbly-wrapper"
 
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
-      className
-    )}
-    {...props}
-  />
+  <WobblyWrapper className="block">
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-lg border bg-card text-card-foreground shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  </WobblyWrapper>
 ))
 Card.displayName = "Card"
 

--- a/src/components/ui/wobbly-wrapper.tsx
+++ b/src/components/ui/wobbly-wrapper.tsx
@@ -1,0 +1,34 @@
+"use client"
+
+import * as React from "react"
+import { RoughNotation } from "react-rough-notation"
+
+interface WobblyWrapperProps {
+  children: React.ReactElement
+  color?: string
+  className?: string
+}
+
+export function WobblyWrapper({
+  children,
+  color = "var(--foreground)",
+  className,
+}: WobblyWrapperProps) {
+  const canAnnotate =
+    typeof window !== "undefined" &&
+    typeof SVGPathElement !== "undefined" &&
+    // @ts-expect-error: getTotalLength may not exist in non-browser environments
+    typeof SVGPathElement.prototype.getTotalLength === "function"
+
+  if (!canAnnotate) {
+    return <span className={className ?? "inline-block"}>{children}</span>
+  }
+
+  return (
+    <span className={className ?? "inline-block"}>
+      <RoughNotation type="box" strokeWidth={2} padding={2} color={color} show>
+        {children}
+      </RoughNotation>
+    </span>
+  )
+}


### PR DESCRIPTION
## Summary
- add WobblyWrapper to render rough.js style borders
- wrap button and card components with wobbly effect
- guard profile update form when no user is present

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: MapView > keeps map visible when AR permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8f75c8f0832198742b3429426262