### PR TITLE
Add hand-drawn styling to key containers

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -82,8 +82,26 @@ body {
   * {
     @apply border-border;
   }
-  body {
+body {
     @apply bg-background text-foreground;
+  }
+}
+
+@layer components {
+  .hand-drawn {
+    @apply relative rounded-xl border-2 shadow-md;
+  }
+  .hand-drawn::after {
+    content: "";
+    position: absolute;
+    top: 4px;
+    left: 4px;
+    width: 100%;
+    height: 100%;
+    border-radius: inherit;
+    border: 2px solid hsl(var(--border));
+    opacity: 0.2;
+    z-index: -1;
   }
 }
 

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -102,7 +102,7 @@ function UpdateProfileForm({ uid, currentDisplayName }: { uid: string, currentDi
 
 function StatCard({ icon: Icon, title, value, isLoading }: { icon: React.ElementType, title: string, value: number | string, isLoading: boolean }) {
     return (
-        <Card>
+        <Card className="hand-drawn">
             <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-sm font-medium">{title}</CardTitle>
                 <Icon className="h-4 w-4 text-muted-foreground" />
@@ -268,7 +268,7 @@ export default function ProfilePage() {
                     <p className="text-muted-foreground">
                         {user?.isAnonymous ? "Anonymous User" : user?.email}
                     </p>
-                    {!user?.isAnonymous && (
+                    {user && !user.isAnonymous && (
                         <div className="mt-2">
                              <UpdateProfileForm uid={user.uid} currentDisplayName={displayName} />
                         </div>

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -277,14 +277,15 @@ function MapViewContent() {
 
   return (
     <div className="h-screen w-screen relative">
-      <ARView
-        ref={arViewRef}
-        notes={notes}
-        style={{ display: isARViewVisible ? 'block' : 'none' }}
-        onSelectNote={handleMarkerClick}
-        onReturnToMap={() => setARViewVisible(false)}
-        onCreateNote={handleARCreateNote}
-      />
+      {isARViewVisible && (
+        <ARView
+          ref={arViewRef}
+          notes={notes}
+          onSelectNote={handleMarkerClick}
+          onReturnToMap={() => setARViewVisible(false)}
+          onCreateNote={handleARCreateNote}
+        />
+      )}
       <Map
         ref={mapRef}
         {...viewState}

--- a/src/components/note-view.tsx
+++ b/src/components/note-view.tsx
@@ -236,7 +236,7 @@ export default function NoteView({
             </div>
             <span>{note.createdAt ? new Date(note.createdAt.seconds * 1000).toLocaleDateString() : "Just now"}</span>
           </div>
-          <div className="flex items-center gap-2 flex-wrap">
+          <div className="hand-drawn flex items-center gap-2 flex-wrap p-2">
             <Button variant="outline" size="sm" onClick={handleLikeToggle} disabled={isLiking || note.authorUid === user?.uid}>
               <Heart className={cn("h-4 w-4 mr-2", isLiked && "fill-destructive text-destructive")} />
               {note.score}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-lg border bg-card text-card-foreground shadow-sm",
+      "rounded-xl border-2 bg-card text-card-foreground shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- Give shared Card components a 12px radius and 2px stroke
- Introduce reusable `hand-drawn` class for optional ink-style borders
- Apply hand-drawn treatment to profile stat cards, note actions, and unmount AR view when hidden

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba8fe3e2848321a30e2c2c2936dcae