### PR TITLE
Remove AR mode from map view

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, fireEvent, cleanup, waitFor, act } from '@testing-library/react';
+import { render, cleanup, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import MapView from './map-view';
 
@@ -39,25 +39,8 @@ vi.mock('@/hooks/use-proximity-notifications', () => ({
   useProximityNotifications: () => {},
 }));
 
-const useARModeMock = vi.hoisted(() => vi.fn());
-vi.mock('@/hooks/use-ar-mode', () => ({
-  useARMode: useARModeMock,
-}));
-
 vi.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }));
 vi.mock('next/navigation', () => ({ useSearchParams: () => new URLSearchParams() }));
-
-const enterARHandler = vi.hoisted(() => vi.fn());
-vi.mock('./ar-view', () => {
-  const MockARView = React.forwardRef(
-    ({ onReturnToMap, style }: any, ref: any) => {
-      React.useImperativeHandle(ref, () => ({ enterAR: enterARHandler }));
-      return <div data-testid="arview" style={style} onClick={onReturnToMap}></div>;
-    }
-  );
-  MockARView.displayName = 'MockARView';
-  return { __esModule: true, default: MockARView };
-});
 vi.mock('./notifications-button', () => ({ NotificationsButton: () => <div /> }));
 vi.mock('./note-sheet-content', () => ({ __esModule: true, default: () => <div /> }));
 vi.mock('./compass-view', () => ({ __esModule: true, default: () => <div /> }));
@@ -83,74 +66,16 @@ vi.mock('./ui/badge', () => ({ Badge: ({ children }: any) => <span>{children}</s
 beforeEach(() => {
   useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: false, error: null });
   useToastMock.mockReturnValue({ toast: vi.fn() });
-  useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission: vi.fn(), arError: null, setArError: vi.fn() });
 });
 
 afterEach(() => {
   cleanup();
-  useARModeMock.mockReset();
   useNotesMock.mockReset();
   useToastMock.mockReset();
-  enterARHandler.mockReset();
   window.localStorage.clear();
 });
 
 describe('MapView', () => {
-  it('enters AR view when permission granted and enable AR clicked', async () => {
-    const requestPermission = vi.fn().mockResolvedValue(true);
-    useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission, arError: null, setArError: vi.fn() });
-    const { getAllByTestId, getByText, getByTestId, queryByTestId } = render(<MapView />);
-    fireEvent.click(getByTestId('onboarding-overlay'));
-    await waitFor(() => expect(() => getByTestId('onboarding-overlay')).toThrow());
-    await act(async () => {
-      fireEvent.click(getByText('Enable AR'));
-    });
-    await waitFor(() => expect(enterARHandler).toHaveBeenCalled());
-    await waitFor(() => expect(getByTestId('arview')).toBeTruthy());
-    const maps = getAllByTestId('map');
-    const map = maps[maps.length - 1] as HTMLDivElement;
-    expect(map.style.display).toBe('none');
-    expect(queryByTestId('arview')).toBeTruthy();
-  });
-
-  it('keeps map visible when AR permission denied', async () => {
-    const requestPermission = vi.fn().mockResolvedValue(false);
-    useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission, arError: null, setArError: vi.fn() });
-    const { getAllByTestId, getByText, getByTestId, queryByTestId } = render(<MapView />);
-    fireEvent.click(getByTestId('onboarding-overlay'));
-    await waitFor(() => expect(() => getByTestId('onboarding-overlay')).toThrow());
-    await act(async () => {
-      fireEvent.click(getByText('Enable AR'));
-    });
-    await waitFor(() => {
-      const maps = getAllByTestId('map');
-      const map = maps[maps.length - 1] as HTMLDivElement;
-      expect(map.style.display).toBe('block');
-      const ar = queryByTestId('arview') as HTMLDivElement | null;
-      expect(ar?.style.display).toBe('none');
-    });
-  });
-
-  it('shows map after returning from AR view', async () => {
-    const requestPermission = vi.fn().mockResolvedValue(true);
-    useARModeMock.mockReturnValue({ permissionGranted: false, requestPermission, arError: null, setArError: vi.fn() });
-    const { getAllByTestId, getByText, getByTestId, queryByTestId } = render(<MapView />);
-    fireEvent.click(getByTestId('onboarding-overlay'));
-    await waitFor(() => expect(() => getByTestId('onboarding-overlay')).toThrow());
-    await act(async () => {
-      fireEvent.click(getByText('Enable AR'));
-    });
-    await waitFor(() => expect(getByTestId('arview')).toBeTruthy());
-    fireEvent.click(getByTestId('arview'));
-    await waitFor(() => {
-      const ar = queryByTestId('arview') as HTMLDivElement | null;
-      expect(ar?.style.display).toBe('none');
-    });
-    const maps = getAllByTestId('map');
-    const map = maps[maps.length - 1] as HTMLDivElement;
-    expect(map.style.display).toBe('block');
-  });
-
   it('renders loader while loading', () => {
     useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null });
     const { getByTestId } = render(<MapView />);

--- a/src/components/ui/wobbly-wrapper.tsx
+++ b/src/components/ui/wobbly-wrapper.tsx
@@ -17,7 +17,6 @@ export function WobblyWrapper({
   const canAnnotate =
     typeof window !== "undefined" &&
     typeof SVGPathElement !== "undefined" &&
-    // @ts-expect-error: getTotalLength may not exist in non-browser environments
     typeof SVGPathElement.prototype.getTotalLength === "function"
 
   if (!canAnnotate) {


### PR DESCRIPTION
## Summary
- strip AR view imports, state, and controls from map view component
- remove AR-specific tests for map view
- clean up unused `@ts-expect-error` in wobbly wrapper

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba9515b98c8321bfb462568e839fd2