### PR TITLE
Remove AR references from UI and fix typecheck

### DIFF
--- a/src/app/admin/TestModeTab.tsx
+++ b/src/app/admin/TestModeTab.tsx
@@ -65,7 +65,7 @@ export function TestModeTab() {
       <CardHeader>
         <CardTitle>Device Simulation</CardTitle>
         <CardDescription>
-          Override device sensors for testing features like the compass or AR mode on a desktop.
+          Override device sensors for testing features like the compass on a desktop.
           Refresh the page to see changes take effect.
         </CardDescription>
       </CardHeader>

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -32,11 +32,6 @@ export default function OnboardingOverlay() {
       <div className="absolute inset-0 bg-black/60" />
 
       <div className="pointer-events-none">
-        <div className="absolute top-16 right-4 text-right">
-          <div className="bg-background/90 text-foreground text-xs px-2 py-1 rounded-md shadow">
-            Toggle AR
-          </div>
-        </div>
         <div className="absolute bottom-40 right-20 text-right">
           <div className="bg-background/90 text-foreground text-xs px-2 py-1 rounded-md shadow">
             Center on your location

--- a/src/components/ui/wobbly-wrapper.tsx
+++ b/src/components/ui/wobbly-wrapper.tsx
@@ -17,7 +17,6 @@ export function WobblyWrapper({
   const canAnnotate =
     typeof window !== "undefined" &&
     typeof SVGPathElement !== "undefined" &&
-    // @ts-expect-error: getTotalLength may not exist in non-browser environments
     typeof SVGPathElement.prototype.getTotalLength === "function"
 
   if (!canAnnotate) {


### PR DESCRIPTION
## Summary
- remove Toggle AR onboarding hint
- update Test Mode description to exclude AR wording
- drop unused ts-expect-error in wobbly wrapper so typecheck passes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba951cd3148321ab49c6f94d73cb1d