### PR TITLE
chore: remove AR analytics events

### DIFF
--- a/src/components/ui/wobbly-wrapper.tsx
+++ b/src/components/ui/wobbly-wrapper.tsx
@@ -17,7 +17,6 @@ export function WobblyWrapper({
   const canAnnotate =
     typeof window !== "undefined" &&
     typeof SVGPathElement !== "undefined" &&
-    // @ts-expect-error: getTotalLength may not exist in non-browser environments
     typeof SVGPathElement.prototype.getTotalLength === "function"
 
   if (!canAnnotate) {

--- a/src/hooks/use-ar-mode.ts
+++ b/src/hooks/use-ar-mode.ts
@@ -1,9 +1,7 @@
-
 "use client";
 
 import { useState } from "react";
 import { useOrientation } from "./use-orientation";
-import { trackEvent } from "@/lib/analytics";
 
 export function useARMode() {
   const {
@@ -20,7 +18,6 @@ export function useARMode() {
     if (!navigator.xr?.isSessionSupported) {
       const errorMsg = "AR mode is not supported on this device or browser.";
       setArError(errorMsg);
-      trackEvent("ar_launch_failed", { reason: "xr_unsupported" });
       return false;
     }
 
@@ -29,13 +26,11 @@ export function useARMode() {
       if (!supported) {
         const errorMsg = "AR mode is not supported on this device or browser.";
         setArError(errorMsg);
-        trackEvent("ar_launch_failed", { reason: "xr_unsupported" });
         return false;
       }
     } catch {
       const errorMsg = "Unable to verify AR support on this device.";
       setArError(errorMsg);
-      trackEvent("ar_launch_failed", { reason: "xr_check_failed" });
       return false;
     }
 
@@ -43,15 +38,12 @@ export function useARMode() {
     if (!orient) {
       const errorMsg = "Motion sensor access is required for AR mode. Please enable it in your browser settings.";
       setArError(errorMsg);
-      trackEvent("ar_permission_denied", { type: "orientation" });
-      trackEvent("ar_launch_failed", { reason: "orientation_denied" });
       return false;
     }
 
     if (!navigator.mediaDevices?.getUserMedia) {
       const errorMsg = "Your browser does not support the necessary camera APIs for AR mode.";
       setArError(errorMsg);
-      trackEvent("ar_launch_failed", { reason: "media_devices_unsupported" });
       return false;
     }
 
@@ -63,7 +55,6 @@ export function useARMode() {
         stream.removeTrack(track);
       });
       setCameraPermissionGranted(true);
-      trackEvent("ar_permission_granted");
       return true;
     } catch (err: any) {
       let errorMsg = "An unknown error occurred while trying to access the camera.";
@@ -72,8 +63,6 @@ export function useARMode() {
       }
       setArError(errorMsg);
       setCameraPermissionGranted(false);
-      trackEvent("ar_permission_denied", { type: "camera" });
-      trackEvent("ar_launch_failed", { reason: "camera_denied" });
       return false;
     }
   };

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -3,24 +3,6 @@ import { app, isFirebaseConfigured } from './firebase';
 
 let analytics: Analytics | undefined;
 
-type ARLaunchFailedReason =
-  | 'xr_unsupported'
-  | 'xr_check_failed'
-  | 'orientation_denied'
-  | 'media_devices_unsupported'
-  | 'camera_denied';
-
-type ARPermissionType = 'orientation' | 'camera';
-
-export function trackEvent(
-  event: 'ar_launch_failed',
-  params: { reason: ARLaunchFailedReason },
-): void;
-export function trackEvent(
-  event: 'ar_permission_denied',
-  params: { type: ARPermissionType },
-): void;
-export function trackEvent(event: 'ar_permission_granted'): void;
 export function trackEvent(event: string, params?: Record<string, unknown>): void;
 export function trackEvent(event: string, params?: Record<string, unknown>) {
   if (typeof window === 'undefined' || !isFirebaseConfigured) return;

--- a/src/types/ambient.d.ts
+++ b/src/types/ambient.d.ts
@@ -2,6 +2,7 @@ declare module 'geofire-common';
 declare module 'vitest';
 declare module 'next-themes';
 declare module 'next-themes/dist/types';
+declare module 'react-rough-notation';
 
 interface BeforeInstallPromptEvent extends Event {
   readonly platforms: string[];


### PR DESCRIPTION
## Summary
- remove AR-specific analytics types and overloads
- stop logging AR analytics events
- add missing type declaration for react-rough-notation

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba951f401c8321a537399da7e4bf78