### PR TITLE
Add note text state and counter to note form

### DIFF
--- a/src/components/create-note-form.test.tsx
+++ b/src/components/create-note-form.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import CreateNoteForm from './create-note-form';
+
+vi.mock('@/components/auth-provider', () => ({
+  useAuth: () => ({ user: { uid: 'u1' } }),
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: any) => React.createElement('img', props),
+}));
+
+vi.mock('./ui/sheet', () => ({
+  SheetHeader: ({ children }: any) => <div>{children}</div>,
+  SheetFooter: ({ children }: any) => <div>{children}</div>,
+  SheetTitle: ({ children }: any) => <div>{children}</div>,
+}));
+
+describe('CreateNoteForm', () => {
+  it('updates character counter as user types', () => {
+    const { getByRole, getByText } = render(
+      <CreateNoteForm userLocation={null} onNoteCreated={() => {}} onClose={() => {}} />
+    );
+    const textarea = getByRole('textbox');
+    fireEvent.change(textarea, { target: { value: 'Hi' } });
+    expect(getByText('2/800')).toBeTruthy();
+    fireEvent.change(textarea, { target: { value: 'Hello there' } });
+    expect(getByText('11/800')).toBeTruthy();
+  });
+});
+


### PR DESCRIPTION
## Summary
- track note text with state and show live character count
- bind textarea to state and reset after submit
- add tests ensuring the counter updates as user types

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa651ec308321aed6c9f68fc65418