### PR TITLE
Add reply length indicator

### DIFF
--- a/src/components/reply-form.test.tsx
+++ b/src/components/reply-form.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from "react";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import ReplyForm from "./reply-form";
+
+vi.mock("./auth-provider", () => ({
+  useAuth: () => ({ user: { uid: "123" } }),
+}));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock("firebase/firestore", () => ({
+  addDoc: vi.fn(),
+  collection: vi.fn(),
+  serverTimestamp: vi.fn(),
+}));
+
+vi.mock("@/lib/pseudonym", () => ({
+  getOrCreatePseudonym: vi.fn(),
+}));
+
+vi.mock("@/lib/firebase", () => ({
+  db: {},
+}));
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("ReplyForm", () => {
+  it("shows character count and updates as user types", () => {
+    render(<ReplyForm noteId="1" />);
+    const textarea = screen.getByRole("textbox");
+    screen.getByText("0/120");
+    fireEvent.change(textarea, { target: { value: "Hello" } });
+    screen.getByText("5/120");
+  });
+
+  it("does not exceed 120 characters", () => {
+    render(<ReplyForm noteId="1" />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "a".repeat(130) } });
+    expect(textarea.value.length).toBe(120);
+    screen.getByText("120/120");
+  });
+});

--- a/src/components/reply-form.tsx
+++ b/src/components/reply-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import React, { useState } from "react";
 import { Send } from "lucide-react";
 import { addDoc, collection, serverTimestamp } from "firebase/firestore";
 import { z } from "zod";
@@ -104,13 +104,14 @@ export default function ReplyForm({
         <Textarea
           name="text"
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => setText(e.target.value.slice(0, 120))}
           placeholder="Add a reply... (Max 120 chars)"
           maxLength={120}
           rows={1}
           required
           className="flex-grow min-h-0"
         />
+        <p className="text-xs text-muted-foreground text-right">{text.length}/120</p>
         {error && <p className="text-sm text-destructive mt-1">{error}</p>}
       </div>
       <Button type="submit" size="icon" className="h-full" disabled={isSubmitting}>


### PR DESCRIPTION
## Summary
- Track reply input in state and clamp to 120 characters
- Display live character count below the reply textarea
- Test reply form character counter behavior

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa6535f3883218f3e9cf22ecbe133