### PR TITLE
feat: add help overlay trigger

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { render, cleanup, waitFor, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import MapView from './map-view';
 
@@ -94,6 +94,15 @@ describe('MapView', () => {
     useToastMock.mockReturnValue({ toast: toastFn });
     render(<MapView />);
     await waitFor(() => expect(toastFn).toHaveBeenCalled());
+  });
+
+  it('shows onboarding overlay when help button clicked', async () => {
+    window.localStorage.setItem('onboardingSeen', 'true');
+    const { getByRole, queryByTestId } = render(<MapView />);
+    expect(queryByTestId('onboarding-overlay')).toBeNull();
+    const helpButton = getByRole('button', { name: /help/i });
+    fireEvent.click(helpButton);
+    await waitFor(() => expect(queryByTestId('onboarding-overlay')).toBeTruthy());
   });
 });
 

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -4,7 +4,7 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import Map, { Marker, Popup } from 'react-map-gl/maplibre';
 import type { MapRef, ViewState } from 'react-map-gl/maplibre';
-import { Plus, Compass, LocateFixed } from 'lucide-react';
+import { Plus, Compass, LocateFixed, CircleHelp } from 'lucide-react';
 import { useLocation, Coordinates } from '@/hooks/use-location';
 import { useNotes } from '@/hooks/use-notes';
 import { useToast } from '@/hooks/use-toast';
@@ -31,7 +31,7 @@ import { ThemeToggle } from './theme-toggle';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
 import { NotificationsButton } from './notifications-button';
-import OnboardingOverlay from './onboarding-overlay';
+import OnboardingOverlay, { type OnboardingOverlayHandle } from './onboarding-overlay';
 import { MapSkeleton } from './map-skeleton';
 import { NdIcon } from './ui/nd-icon';
 
@@ -53,6 +53,7 @@ function MapViewContent() {
   const [newNoteLocation, setNewNoteLocation] = useState<Coordinates | null>(null);
   const [isCompassViewOpen, setCompassViewOpen] = useState(false);
   const mapRef = useRef<MapRef | null>(null);
+  const onboardingRef = useRef<OnboardingOverlayHandle>(null);
   const moveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastFetchCenterRef = useRef<[number, number] | null>(null);
@@ -294,7 +295,7 @@ function MapViewContent() {
         )}
       </Map>
 
-      <OnboardingOverlay />
+      <OnboardingOverlay ref={onboardingRef} />
 
       {loading && (
         <div data-testid="map-loading" className="absolute inset-0 z-20">
@@ -321,6 +322,20 @@ function MapViewContent() {
               Enable Location
             </Button>
           )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            onClick={() => {
+              if (typeof window !== 'undefined') {
+                window.localStorage.setItem('onboardingSeen', 'false');
+              }
+              onboardingRef.current?.show();
+            }}
+          >
+            <CircleHelp className="h-4 w-4" />
+            <span className="sr-only">Help</span>
+          </Button>
           <ThemeToggle />
           <NotificationsButton />
           <AuthButton />

--- a/src/components/onboarding-overlay.tsx
+++ b/src/components/onboarding-overlay.tsx
@@ -1,14 +1,22 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, forwardRef, useImperativeHandle } from 'react';
 
-export default function OnboardingOverlay() {
+export interface OnboardingOverlayHandle {
+  show: () => void;
+}
+
+const OnboardingOverlay = forwardRef<OnboardingOverlayHandle>((_, ref) => {
   const [visible, setVisible] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    show: () => setVisible(true),
+  }));
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
       const seen = window.localStorage.getItem('onboardingSeen');
-      if (!seen) {
+      if (seen !== 'true') {
         setVisible(true);
       }
     }
@@ -50,5 +58,9 @@ export default function OnboardingOverlay() {
       </div>
     </div>
   );
-}
+});
+
+OnboardingOverlay.displayName = 'OnboardingOverlay';
+
+export default OnboardingOverlay;
 


### PR DESCRIPTION
## Summary
- expose onboarding overlay control via ref
- add help button to show onboarding overlay and reset seen flag
- test map help button reveals onboarding overlay

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baa65fef9083218f18f9fa8e53f207