### PR TITLE
feat: add sketch theme and icon demo

### DIFF
--- a/src/app/demo/sketch/page.tsx
+++ b/src/app/demo/sketch/page.tsx
@@ -7,7 +7,7 @@ import Icon from '@/components/ui/Icon';
 
 export default function Page() {
   return (
-    <main style={{ maxWidth: 800, margin: '40px auto', padding: '0 16px' }}>
+    <main className="sketch" style={{ maxWidth: 800, margin: '40px auto', padding: '0 16px' }}>
       <SketchCard title="NoteDrop (Sketch UI)">
         <p>Prototype vibe: ghost pins, travel-to-reveal. Fonts: Kalam + Patrick Hand.</p>
         <div style={{ display: 'flex', gap: 12, alignItems: 'center', marginTop: 12 }}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -112,16 +112,13 @@ body {
 }
 
 /* Sketch UI tokens and utilities */
-:root {
+.sketch {
   --ink: #333333;
   --paper: #f2f2f2;
   --paper-2: #e0e0e0;
   --accent: #ffd24a; /* single highlight */
   --radius: 14px;
   --stroke: 3px;
-}
-
-html, body {
   background: var(--paper);
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
@@ -168,7 +165,7 @@ html, body {
 }
 
 /* a11y */
-:focus-visible {
+.sketch :focus-visible {
   outline: 3px solid var(--ink);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- scope sketch palette to `.sketch` container to preserve global theme

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb582b7af88321992ef9bd00f9adbc