### PR TITLE
feat: add sketch theme option

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -116,9 +116,47 @@ body {
   --ink: #333333;
   --paper: #f2f2f2;
   --paper-2: #e0e0e0;
-  --accent: #ffd24a; /* single highlight */
+  --sk-accent: #ffd24a; /* single highlight */
   --radius: 14px;
   --stroke: 3px;
+
+  /* Map to app theme tokens */
+  --background: 0 0% 95%;
+  --foreground: 0 0% 20%;
+  --card: 0 0% 95%;
+  --card-foreground: 0 0% 20%;
+  --popover: 0 0% 95%;
+  --popover-foreground: 0 0% 20%;
+  --primary: 45 100% 65%;
+  --primary-foreground: 0 0% 20%;
+  --secondary: 0 0% 88%;
+  --secondary-foreground: 0 0% 20%;
+  --muted: 0 0% 88%;
+  --muted-foreground: 0 0% 20%;
+  --accent: 45 100% 65%;
+  --accent-foreground: 0 0% 20%;
+  --destructive: 0 84.2% 60.2%;
+  --destructive-foreground: 210 20% 98%;
+  --border: 0 0% 20%;
+  --input: 0 0% 88%;
+  --ring: 45 100% 65%;
+  --chart-1: 45 100% 65%;
+  --chart-2: 0 0% 20%;
+  --chart-3: 0 0% 88%;
+  --chart-4: 0 0% 50%;
+  --chart-5: 0 0% 70%;
+  --sidebar-background: 0 0% 95%;
+  --sidebar-foreground: 0 0% 20%;
+  --sidebar-primary: 45 100% 65%;
+  --sidebar-primary-foreground: 0 0% 20%;
+  --sidebar-accent: 0 0% 88%;
+  --sidebar-accent-foreground: 0 0% 20%;
+  --sidebar-border: 0 0% 20%;
+  --sidebar-ring: 45 100% 65%;
+  --gray-100: 0 0% 95%;
+  --gray-200: 0 0% 88%;
+  --gold: 51 100% 50%;
+
   background: var(--paper);
   color: var(--ink);
   -webkit-font-smoothing: antialiased;
@@ -154,7 +192,7 @@ body {
 }
 .sk-btn:active { transform: translateY(1px); }
 .sk-btn[disabled] { opacity: .5; cursor: not-allowed; filter: grayscale(.5); }
-.sk-btn.sk-cta { background: var(--accent); }
+.sk-btn.sk-cta { background: var(--sk-accent); }
 
 .sk-pill {
   display: inline-block;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -71,6 +71,7 @@ export default function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          themes={['light', 'dark', 'sketch']}
         >
           <SettingsProvider>
             <AuthProvider>

--- a/src/components/theme-toggle.test.tsx
+++ b/src/components/theme-toggle.test.tsx
@@ -1,0 +1,33 @@
+/**
+ * @vitest-environment jsdom
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useTheme } from 'next-themes';
+
+vi.mock('next-themes', () => ({
+  useTheme: vi.fn(),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick }: any) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+}));
+
+import { ThemeToggle } from './theme-toggle';
+
+describe('ThemeToggle', () => {
+  it('allows selecting sketch theme', async () => {
+    const setTheme = vi.fn();
+    const useThemeMock = useTheme as unknown as ReturnType<typeof vi.fn>;
+    useThemeMock.mockReturnValue({ setTheme });
+    const { getByText } = render(<ThemeToggle />);
+    fireEvent.click(getByText('Sketch'));
+    expect(setTheme).toHaveBeenCalledWith('sketch');
+  });
+});

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -31,6 +31,9 @@ export function ThemeToggle() {
         <DropdownMenuItem onClick={() => setTheme("dark")}>
           Dark
         </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("sketch")}>
+          Sketch
+        </DropdownMenuItem>
         <DropdownMenuItem onClick={() => setTheme("system")}>
           System
         </DropdownMenuItem>


### PR DESCRIPTION
## Summary
- allow selecting "Sketch" palette from theme dropdown
- register sketch theme with next-themes provider
- map sketch CSS variables to app theme tokens

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb5a111ee88321bfc9910a42cbddf5