### PR TITLE
Make sketch theme look sketchier

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -29,6 +29,7 @@ body {
     --border: 220 13% 91%;
     --input: 220 13% 91%;
     --ring: 221.2 83.2% 53.3%;
+    --font-hand: "Architects Daughter","Kalam","Patrick Hand";
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
@@ -165,16 +166,20 @@ body {
 }
 
 /* Sketch UI primitives */
+
 .sk-card {
   background: var(--paper);
   border: var(--stroke) solid var(--ink);
+  outline: var(--stroke) solid var(--ink);
+  outline-offset: 3px;
   border-radius: var(--radius);
   box-shadow: 0 2px 0 #d7d7d7;
   padding: 16px;
+  filter: url(#sketch);
 }
 
 .sk-title {
-  font-family: "Kalam","Patrick Hand",system-ui,sans-serif;
+  font-family: "Architects Daughter","Kalam","Patrick Hand",system-ui,sans-serif;
   font-weight: 600;
 }
 
@@ -182,13 +187,16 @@ body {
   display: inline-block;
   padding: 12px 18px;
   border: var(--stroke) solid var(--ink);
+  outline: var(--stroke) solid var(--ink);
+  outline-offset: 3px;
   border-radius: 9999px;
   background: #fff;
   color: var(--ink);
   cursor: pointer;
   text-decoration: none;
-  font-family: "Kalam","Patrick Hand",system-ui,sans-serif;
+  font-family: "Architects Daughter","Kalam","Patrick Hand",system-ui,sans-serif;
   transition: transform .02s ease-in-out;
+  filter: url(#sketch);
 }
 .sk-btn:active { transform: translateY(1px); }
 .sk-btn[disabled] { opacity: .5; cursor: not-allowed; filter: grayscale(.5); }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -54,7 +54,7 @@ export default function RootLayout({
       <head>
         {/* Handwritten, readable fonts */}
         <link
-          href="https://fonts.googleapis.com/css2?family=Kalam:wght@300;400;700&family=Patrick+Hand&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Architects+Daughter&family=Kalam:wght@300;400;700&family=Patrick+Hand&display=swap"
           rel="stylesheet"
         />
         {/* wired-elements (sketchy web components) */}

--- a/src/components/ui/SketchSprite.tsx
+++ b/src/components/ui/SketchSprite.tsx
@@ -14,14 +14,14 @@ export default function SketchSprite() {
   <defs>
     <filter id="sketch" x="-10%" y="-10%" width="120%" height="120%">
       <feTurbulence type="fractalNoise" baseFrequency="0.7" numOctaves="2" seed="11" result="n"/>
-      <feDisplacementMap in="SourceGraphic" in2="n" scale="0.8" xChannelSelector="R" yChannelSelector="G"/>
+      <feDisplacementMap in="SourceGraphic" in2="n" scale="1.2" xChannelSelector="R" yChannelSelector="G"/>
     </filter>
     <style>
-      .i { stroke:#333; stroke-width:3; stroke-linecap:round; stroke-linejoin:round; fill:none; }
+      .i { stroke:#333; stroke-width:4; stroke-linecap:round; stroke-linejoin:round; fill:none; }
       .paper { fill:#f2f2f2; }
       .ink { fill:#333; }
       .accent { fill:#ffd24a; }
-      .muted { stroke:#666; fill:none; }
+      .muted { stroke:#666; stroke-width:4; fill:none; }
     </style>
   </defs>
 


### PR DESCRIPTION
## Summary
- add Architects Daughter font and expose font-hand CSS variable
- jitter cards and buttons with double-stroked borders
- thicken sketch icon strokes and increase displacement jitter

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb639982288321aaa3dc9399d72ec8