### PR TITLE
Intensify sketch theme with hand-drawn borders

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -168,13 +168,25 @@ body {
 /* Sketch UI primitives */
 
 .sk-card {
+  position: relative;
   background: var(--paper);
   border: var(--stroke) solid var(--ink);
-  outline: var(--stroke) solid var(--ink);
-  outline-offset: 3px;
   border-radius: var(--radius);
   box-shadow: 0 2px 0 #d7d7d7;
   padding: 16px;
+  filter: url(#sketch);
+}
+
+.sk-card::after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  right: -3px;
+  bottom: -3px;
+  border: var(--stroke) solid var(--ink);
+  border-radius: var(--radius);
+  pointer-events: none;
   filter: url(#sketch);
 }
 
@@ -184,11 +196,10 @@ body {
 }
 
 .sk-btn {
+  position: relative;
   display: inline-block;
   padding: 12px 18px;
   border: var(--stroke) solid var(--ink);
-  outline: var(--stroke) solid var(--ink);
-  outline-offset: 3px;
   border-radius: 9999px;
   background: #fff;
   color: var(--ink);
@@ -198,8 +209,21 @@ body {
   transition: transform .02s ease-in-out;
   filter: url(#sketch);
 }
+
+.sk-btn::after {
+  content: '';
+  position: absolute;
+  top: -3px;
+  left: -3px;
+  right: -3px;
+  bottom: -3px;
+  border: var(--stroke) solid var(--ink);
+  border-radius: 9999px;
+  pointer-events: none;
+  filter: url(#sketch);
+}
 .sk-btn:active { transform: translateY(1px); }
-.sk-btn[disabled] { opacity: .5; cursor: not-allowed; filter: grayscale(.5); }
+.sk-btn[disabled] { opacity: .5; cursor: not-allowed; filter: url(#sketch) grayscale(.5); }
 .sk-btn.sk-cta { background: var(--sk-accent); }
 
 .sk-pill {
@@ -208,6 +232,7 @@ body {
   padding: 4px 10px;
   border: var(--stroke) solid var(--ink);
   background: #fff;
+  filter: url(#sketch);
 }
 
 /* a11y */

--- a/src/components/ui/SketchSprite.tsx
+++ b/src/components/ui/SketchSprite.tsx
@@ -13,8 +13,8 @@ export default function SketchSprite() {
 <svg xmlns="http://www.w3.org/2000/svg" style="display:none">
   <defs>
     <filter id="sketch" x="-10%" y="-10%" width="120%" height="120%">
-      <feTurbulence type="fractalNoise" baseFrequency="0.7" numOctaves="2" seed="11" result="n"/>
-      <feDisplacementMap in="SourceGraphic" in2="n" scale="1.2" xChannelSelector="R" yChannelSelector="G"/>
+      <feTurbulence type="fractalNoise" baseFrequency="0.8" numOctaves="3" seed="11" result="n"/>
+      <feDisplacementMap in="SourceGraphic" in2="n" scale="3" xChannelSelector="R" yChannelSelector="G"/>
     </filter>
     <style>
       .i { stroke:#333; stroke-width:4; stroke-linecap:round; stroke-linejoin:round; fill:none; }


### PR DESCRIPTION
## Summary
- Replace crisp outlines with filtered pseudo-elements for hand-drawn card and button borders
- Apply sketch filter to pills and increase turbulence/scale for overall sketch effect

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbf7e48d3c832183788a4889912040