### PR TITLE
Add favicon to prevent 404 and expose in metadata

### DIFF
--- a/src/app/favicon.ico/route.ts
+++ b/src/app/favicon.ico/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function GET() {
+  const svgPath = path.join(process.cwd(), 'public', 'favicon.svg');
+  const svg = await fs.readFile(svgPath);
+  return new NextResponse(svg, {
+    headers: {
+      'Content-Type': 'image/svg+xml',
+    },
+  });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,7 +26,10 @@ export const metadata: Metadata = {
   description: 'Leave and discover location-anchored virtual post-its.',
   manifest: '/manifest.json',
   icons: {
-    icon: '/favicon.svg',
+    icon: [
+      { url: '/favicon.ico', sizes: 'any' },
+      { url: '/favicon.svg', type: 'image/svg+xml' },
+    ],
     apple: '/icon-512.png',
   },
 };


### PR DESCRIPTION
## Summary
- serve `/favicon.ico` via Next.js route backed by existing `favicon.svg`
- remove `favicon.ico` binary asset to keep repository text-only
- expose both `.ico` and `.svg` icons in layout metadata for broad browser support

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc01a0fa2c8321a2396dc4a44562f9