### PR TITLE
Serve service worker from route

### DIFF
--- a/src/app/sw.js/route.ts
+++ b/src/app/sw.js/route.ts
@@ -1,0 +1,10 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export async function GET() {
+  const filePath = path.join(process.cwd(), 'public', 'sw.js');
+  const file = await fs.readFile(filePath, 'utf8');
+  return new Response(file, {
+    headers: { 'Content-Type': 'application/javascript' },
+  });
+}

--- a/src/sw-route.test.ts
+++ b/src/sw-route.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { GET } from './app/sw.js/route';
+
+
+describe('sw.js route', () => {
+  it('serves service worker script', async () => {
+    const res = await GET();
+    const text = await res.text();
+    expect(res.headers.get('Content-Type')).toBe('application/javascript');
+    expect(text).toContain('NoteDrop Service Worker');
+  });
+});

--- a/src/sw.test.ts
+++ b/src/sw.test.ts
@@ -11,6 +11,7 @@ function setupSW() {
       listeners[type] = cb;
     },
     clients: { claim: vi.fn() },
+    location: { origin: 'https://example.com' },
   };
 
   const cachesStore = new Map<string, Map<string, Response>>();


### PR DESCRIPTION
## Summary
- add Next.js route to serve `sw.js` so the service worker is available in production
- cover the route with a unit test and adjust service worker tests to provide a default location

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc62f47510832185885a6a6086c033