### PR TITLE
feat: delay map loader to reduce flashing

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, cleanup, waitFor } from '@testing-library/react';
+import { render, cleanup, waitFor, act } from '@testing-library/react';
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import MapView from './map-view';
 
@@ -77,14 +77,20 @@ afterEach(() => {
   useNotesMock.mockReset();
   useToastMock.mockReset();
   window.localStorage.clear();
+  vi.useRealTimers();
 });
 
 describe('MapView', () => {
-  it('renders loader while loading', () => {
+  it('renders loader after delay when loading', () => {
+    vi.useFakeTimers();
     useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null });
-    const { getByTestId } = render(<MapView />);
-    const loader = getByTestId('map-loading');
-    expect(loader.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+    const { queryByTestId } = render(<MapView />);
+    expect(queryByTestId('map-loading')).toBeNull();
+    act(() => {
+      vi.advanceTimersByTime(350);
+    });
+    const loader = queryByTestId('map-loading');
+    expect(loader).toBeTruthy();
   });
 
   it('shows message when no notes', () => {

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -52,6 +52,7 @@ function MapViewContent() {
   const [isCreatingNote, setCreatingNote] = useState(false);
   const [newNoteLocation, setNewNoteLocation] = useState<Coordinates | null>(null);
   const [isCompassViewOpen, setCompassViewOpen] = useState(false);
+  const [showLoader, setShowLoader] = useState(false);
   const mapRef = useRef<MapRef | null>(null);
   const moveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
@@ -69,6 +70,18 @@ function MapViewContent() {
       });
     }
   }, [error, toast]);
+
+  useEffect(() => {
+    let timer: NodeJS.Timeout | null = null;
+    if (loading) {
+      timer = setTimeout(() => setShowLoader(true), 300);
+    } else {
+      setShowLoader(false);
+    }
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
+  }, [loading]);
 
   const [viewState, setViewState] = useState<Partial<ViewState>>({
     longitude: DEFAULT_CENTER.longitude,
@@ -306,7 +319,7 @@ function MapViewContent() {
 
       <OnboardingOverlay />
 
-      {loading && (
+      {showLoader && (
         <div data-testid="map-loading" className="absolute inset-0 z-20">
           <MapSkeleton />
         </div>


### PR DESCRIPTION
## Summary
- delay map skeleton loader to avoid flashing during quick data fetches
- test loader delay with fake timers

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc653fbf488321b0bbe139e0022199