### PR TITLE
Avoid flashing map tiles on location update

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -93,6 +93,21 @@ describe('MapView', () => {
     expect(loader.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
   });
 
+  it('does not render loader when notes exist', () => {
+    const note = {
+      id: '1',
+      lat: 0,
+      lng: 0,
+      createdAt: { seconds: 0, nanoseconds: 0 },
+      score: 0,
+      type: 'text',
+      teaser: 't',
+    };
+    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: true, error: null });
+    const { queryByTestId } = render(<MapView />);
+    expect(queryByTestId('map-loading')).toBeNull();
+  });
+
   it('shows message when no notes', () => {
     const { getByTestId } = render(<MapView />);
     expect(getByTestId('no-notes')).toBeTruthy();

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -309,7 +309,7 @@ function MapViewContent() {
 
       <OnboardingOverlay />
 
-      {loading && (
+      {loading && notes.length === 0 && (
         <div data-testid="map-loading" className="absolute inset-0 z-20">
           <MapSkeleton />
         </div>


### PR DESCRIPTION
## Summary
- Only display map loading skeleton when there are no existing notes
- Test that loader is hidden once notes are present

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bc668c30188321b7838422a471deb5