### PR TITLE
Avoid map skeleton flashing on location updates

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -71,7 +71,7 @@ vi.mock('./ui/dialog', () => ({
 vi.mock('./ui/badge', () => ({ Badge: ({ children }: any) => <span>{children}</span> }));
 
 beforeEach(() => {
-  useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: false, error: null });
+  useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
   useToastMock.mockReturnValue({ toast: vi.fn() });
   useSearchParamsMock.mockReturnValue(new URLSearchParams());
   useLocationMock.mockReturnValue({ location: null, permissionState: 'granted', requestPermission: vi.fn() });
@@ -86,11 +86,17 @@ afterEach(() => {
 });
 
 describe('MapView', () => {
-  it('renders loader while loading', () => {
-    useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null });
+  it('renders loader before first fetch', () => {
+    useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null, hasFetched: false });
     const { getByTestId } = render(<MapView />);
     const loader = getByTestId('map-loading');
     expect(loader.querySelectorAll('.animate-pulse').length).toBeGreaterThan(0);
+  });
+
+  it('does not render loader after initial fetch', () => {
+    useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: true, error: null, hasFetched: true });
+    const { queryByTestId } = render(<MapView />);
+    expect(queryByTestId('map-loading')).toBeNull();
   });
 
   it('does not render loader when notes exist', () => {
@@ -103,7 +109,7 @@ describe('MapView', () => {
       type: 'text',
       teaser: 't',
     };
-    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: true, error: null });
+    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: true, error: null, hasFetched: true });
     const { queryByTestId } = render(<MapView />);
     expect(queryByTestId('map-loading')).toBeNull();
   });
@@ -115,7 +121,7 @@ describe('MapView', () => {
 
   it('toasts on error', async () => {
     const toastFn = vi.fn();
-    useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: false, error: 'oops' });
+    useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: false, error: 'oops', hasFetched: true });
     useToastMock.mockReturnValue({ toast: toastFn });
     render(<MapView />);
     await waitFor(() => expect(toastFn).toHaveBeenCalled());
@@ -131,7 +137,7 @@ describe('MapView', () => {
       type: 'text',
     };
     useSearchParamsMock.mockReturnValue(new URLSearchParams('note=1'));
-    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null });
+    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
     render(<MapView />);
     await waitFor(() =>
       expect(NoteSheetContentMock).toHaveBeenCalledWith(
@@ -156,7 +162,7 @@ describe('MapView', () => {
       permissionState: 'granted',
       requestPermission: vi.fn(),
     });
-    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null });
+    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
 
     const { getByLabelText, queryByText } = render(<MapView />);
 

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -42,7 +42,7 @@ const HOT_POST_THRESHOLD = 50;
 
 function MapViewContent() {
   const { location, permissionState, requestPermission: requestLocationPermission } = useLocation();
-  const { notes, fetchNotes, loading, error } = useNotes();
+  const { notes, fetchNotes, loading, error, hasFetched } = useNotes();
   const { proximityRadiusM } = useSettings();
   const { toast } = useToast();
   useProximityNotifications(notes, location, proximityRadiusM);
@@ -309,13 +309,13 @@ function MapViewContent() {
 
       <OnboardingOverlay />
 
-      {loading && notes.length === 0 && (
+      {!hasFetched && (
         <div data-testid="map-loading" className="absolute inset-0 z-20">
           <MapSkeleton />
         </div>
       )}
 
-      {!loading && notes.length === 0 && (
+      {hasFetched && !loading && notes.length === 0 && (
         <div
           data-testid="no-notes"
           className="absolute inset-0 z-20 flex items-center justify-center pointer-events-none"

--- a/src/hooks/use-notes.test.ts
+++ b/src/hooks/use-notes.test.ts
@@ -44,6 +44,7 @@ describe('useNotes', () => {
     expect(getDocs).toHaveBeenCalled()
     expect(result.current.loading).toBe(false)
     expect(result.current.error).toBeNull()
+    expect(result.current.hasFetched).toBe(true)
   })
 
   test('propagates fetch errors', async () => {
@@ -55,6 +56,7 @@ describe('useNotes', () => {
     })
     await waitFor(() => expect(result.current.error).toBe('boom'))
     expect(result.current.loading).toBe(false)
+    expect(result.current.hasFetched).toBe(true)
   })
 
   test('clears error after successful fetch', async () => {
@@ -76,6 +78,7 @@ describe('useNotes', () => {
       await result.current.fetchNotes([0, 0])
     })
     await waitFor(() => expect(result.current.error).toBe('fail'))
+    expect(result.current.hasFetched).toBe(true)
 
     await act(async () => {
       await result.current.fetchNotes([0, 0])

--- a/src/hooks/use-notes.ts
+++ b/src/hooks/use-notes.ts
@@ -26,6 +26,7 @@ export function useNotes() {
   const [notes, setNotes] = useState<GhostNote[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [hasFetched, setHasFetched] = useState(false);
 
   const fetchNotes = useCallback(async (center: [number, number]) => {
     if (!db) return;
@@ -84,9 +85,10 @@ export function useNotes() {
       setError(err instanceof Error ? err.message : String(err));
     } finally {
       setLoading(false);
+      setHasFetched(true);
     }
   }, []);
 
-  return { notes, loading, fetchNotes, error };
+  return { notes, loading, fetchNotes, error, hasFetched };
 }
 


### PR DESCRIPTION
## Summary
- track initial notes fetch in `useNotes` with `hasFetched`
- only display map skeleton before first fetch to avoid flashes on each location update
- expand tests for loader behavior and new hook flag

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcdf49d6c88321a2a4baddea4260e0