### PR TITLE
Disable map tile fade to prevent blinking

### DIFF
--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -266,6 +266,7 @@ function MapViewContent() {
         style={{ width: '100%', height: '100%' }}
         mapStyle={mapStyleUrl}
         reuseMaps
+        fadeDuration={0}
         antialias={true}
       >
         {location && (


### PR DESCRIPTION
## Summary
- disable Maplibre tile fade animation so tiles stay visible during view changes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd92e029748321935cfc2f1b68f60b