### PR TITLE
fix: stabilize map view to stop flashing

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -41,8 +41,6 @@ vi.mock('@/hooks/use-proximity-notifications', () => ({
 }));
 
 vi.mock('next-themes', () => ({ useTheme: () => ({ theme: 'light' }) }));
-const useSearchParamsMock = vi.hoisted(() => vi.fn(() => new URLSearchParams()));
-vi.mock('next/navigation', () => ({ useSearchParams: useSearchParamsMock }));
 vi.mock('./notifications-button', () => ({ NotificationsButton: () => <div /> }));
 const NoteSheetContentMock = vi.hoisted(() => vi.fn(() => <div data-testid="note-sheet" />));
 vi.mock('./note-sheet-content', () => ({ __esModule: true, default: NoteSheetContentMock }));
@@ -73,9 +71,9 @@ vi.mock('./ui/badge', () => ({ Badge: ({ children }: any) => <span>{children}</s
 beforeEach(() => {
   useNotesMock.mockReturnValue({ notes: [], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
   useToastMock.mockReturnValue({ toast: vi.fn() });
-  useSearchParamsMock.mockReturnValue(new URLSearchParams());
   useLocationMock.mockReturnValue({ location: null, permissionState: 'granted', requestPermission: vi.fn() });
   NoteSheetContentMock.mockClear();
+  window.history.replaceState({}, '', '/');
 });
 
 afterEach(() => {
@@ -83,6 +81,7 @@ afterEach(() => {
   useNotesMock.mockReset();
   useToastMock.mockReset();
   window.localStorage.clear();
+  window.history.replaceState({}, '', '/');
 });
 
 describe('MapView', () => {
@@ -136,7 +135,7 @@ describe('MapView', () => {
       score: 0,
       type: 'text',
     };
-    useSearchParamsMock.mockReturnValue(new URLSearchParams('note=1'));
+    window.history.replaceState({}, '', '/?note=1');
     useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
     render(<MapView />);
     await waitFor(() =>

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -26,7 +26,6 @@ import {
 import { Badge } from './ui/badge';
 import CompassView from './compass-view';
 import { distanceBetween } from 'geofire-common';
-import { useSearchParams } from 'next/navigation';
 import { ThemeToggle } from './theme-toggle';
 import { useTheme } from 'next-themes';
 import { cn } from '@/lib/utils';
@@ -57,7 +56,7 @@ function MapViewContent() {
   const fetchTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const lastFetchCenterRef = useRef<[number, number] | null>(null);
   const lastFetchTimeRef = useRef<number>(0);
-  const searchParams = useSearchParams();
+  const [searchParams, setSearchParams] = useState<URLSearchParams | null>(null);
   const { theme } = useTheme();
 
   useEffect(() => {
@@ -79,6 +78,16 @@ function MapViewContent() {
   });
   
   useEffect(() => {
+    const updateSearchParams = () => {
+      setSearchParams(new URLSearchParams(window.location.search));
+    };
+    updateSearchParams();
+    window.addEventListener('popstate', updateSearchParams);
+    return () => window.removeEventListener('popstate', updateSearchParams);
+  }, []);
+
+  useEffect(() => {
+    if (!searchParams) return;
     const lat = searchParams.get('lat');
     const lng = searchParams.get('lng');
     const zoom = searchParams.get('zoom');
@@ -92,6 +101,7 @@ function MapViewContent() {
   }, [searchParams]);
 
   useEffect(() => {
+    if (!searchParams) return;
     const noteId = searchParams.get('note');
     if (!noteId) return;
     const note = notes.find((n) => n.id === noteId);
@@ -175,7 +185,7 @@ function MapViewContent() {
   useEffect(() => {
     if (location && mapRef.current) {
       if (
-        !searchParams.get('lat') &&
+        !searchParams?.get('lat') &&
         viewState.longitude === DEFAULT_CENTER.longitude &&
         viewState.latitude === DEFAULT_CENTER.latitude
       ) {
@@ -419,9 +429,5 @@ function MapViewContent() {
 }
 
 export default function MapView() {
-    return (
-        <React.Suspense fallback={<MapSkeleton className="h-screen w-screen" />}>
-            <MapViewContent />
-        </React.Suspense>
-    )
+  return <MapViewContent />;
 }


### PR DESCRIPTION
## Summary
- avoid remounting the map by replacing Next.js `useSearchParams` with a stable `URLSearchParams` listener
- drop the `React.Suspense` wrapper around the map view
- adjust tests to use `window.history` for query params

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdaf9e721c8321a95cc4c408afc8a5