### PR TITLE
fix: update search param listener for client-side navigation

### DIFF
--- a/src/components/map-view.test.tsx
+++ b/src/components/map-view.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import React from 'react';
-import { render, cleanup, waitFor, fireEvent } from '@testing-library/react';
+import { render, cleanup, waitFor, fireEvent, act } from '@testing-library/react';
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest';
 import MapView from './map-view';
 
@@ -138,6 +138,28 @@ describe('MapView', () => {
     window.history.replaceState({}, '', '/?note=1');
     useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
     render(<MapView />);
+    await waitFor(() =>
+      expect(NoteSheetContentMock).toHaveBeenCalledWith(
+        expect.objectContaining({ noteId: '1' }),
+        expect.anything()
+      )
+    );
+  });
+
+  it('reacts to search param changes during session', async () => {
+    const note = {
+      id: '1',
+      lat: 0,
+      lng: 0,
+      createdAt: { seconds: 0, nanoseconds: 0 },
+      score: 0,
+      type: 'text',
+    };
+    useNotesMock.mockReturnValue({ notes: [note], fetchNotes: vi.fn(), loading: false, error: null, hasFetched: true });
+    render(<MapView />);
+    await act(async () => {
+      window.history.pushState({}, '', '/?note=1');
+    });
     await waitFor(() =>
       expect(NoteSheetContentMock).toHaveBeenCalledWith(
         expect.objectContaining({ noteId: '1' }),

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -82,8 +82,26 @@ function MapViewContent() {
       setSearchParams(new URLSearchParams(window.location.search));
     };
     updateSearchParams();
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    history.pushState = ((...args: any[]) => {
+      originalPushState.apply(history, args as any);
+      updateSearchParams();
+    }) as typeof history.pushState;
+
+    history.replaceState = ((...args: any[]) => {
+      originalReplaceState.apply(history, args as any);
+      updateSearchParams();
+    }) as typeof history.replaceState;
+
     window.addEventListener('popstate', updateSearchParams);
-    return () => window.removeEventListener('popstate', updateSearchParams);
+    return () => {
+      window.removeEventListener('popstate', updateSearchParams);
+      history.pushState = originalPushState;
+      history.replaceState = originalReplaceState;
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- update map view to sync search params on history push/replace
- test map view response to runtime query changes

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbfa2a3488321b47757cfb2811511