### PR TITLE
docs(ai): document genkit setup

### DIFF
--- a/src/ai/genkit.ts
+++ b/src/ai/genkit.ts
@@ -1,3 +1,11 @@
+/**
+ * @fileOverview Initializes a Genkit instance to access Google Gemini models
+ * via the googleAI plugin.
+ *
+ * Genkit provides utilities for building and running AI flows in the
+ * application, and the googleAI plugin enables communication with Google's
+ * Gemini models.
+ */
 import {genkit} from 'genkit';
 import {googleAI} from '@genkit-ai/googleai';
 
@@ -13,6 +21,10 @@ if (!process.env.GEMINI_API_KEY || process.env.GEMINI_API_KEY === 'YOUR_GEMINI_A
   );
 }
 
+/**
+ * Genkit client configured for the `googleai/gemini-2.5-flash` model.
+ * Requires the `GEMINI_API_KEY` environment variable to be set.
+ */
 export const ai = genkit({
   plugins: [googleAI()],
   model: 'googleai/gemini-2.5-flash',


### PR DESCRIPTION
## Summary
- explain Genkit and googleAI plugin
- document exported `ai` instance with Gemini model and `GEMINI_API_KEY`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde7d7c820832181d65b1bfb6e6522