### PR TITLE
docs: clarify useNotes behavior

### DIFF
--- a/src/hooks/use-notes.ts
+++ b/src/hooks/use-notes.ts
@@ -19,9 +19,25 @@ import { geohashQueryBounds, distanceBetween } from "geofire-common";
 import { db } from "../lib/firebase";
 import { GhostNote } from "@/types";
 
+// Default search radius in meters
 const RADIUS_M = 5000;
+// Maximum number of notes fetched per request
 const MAX_NOTES = 50;
 
+/**
+ * Retrieves public notes near a given coordinate.
+ *
+ * Geohash query bounds are generated around the center point and each range is
+ * queried in Firestore. Results from overlapping ranges are deduplicated by
+ * document ID before being filtered to the desired radius.
+ *
+ * @returns Object containing:
+ * - `notes`: list of nearby notes
+ * - `loading`: whether a fetch is in progress
+ * - `fetchNotes`: function to trigger the geolocation query
+ * - `error`: error message if the fetch fails
+ * - `hasFetched`: whether a fetch has been attempted
+ */
 export function useNotes() {
   const [notes, setNotes] = useState<GhostNote[]>([]);
   const [loading, setLoading] = useState(false);
@@ -32,7 +48,7 @@ export function useNotes() {
     if (!db) return;
     setLoading(true);
 
-    const bounds = geohashQueryBounds(center, RADIUS_M);
+    const bounds = geohashQueryBounds(center, RADIUS_M); // Geohash ranges covering the search radius
 
     const promises = bounds.map((b: [string, string]) =>
       getDocs(
@@ -50,15 +66,15 @@ export function useNotes() {
     try {
       const snapshots: QuerySnapshot<DocumentData>[] = await Promise.all(promises);
       const notesData: GhostNote[] = [];
-      const seen = new Set<string>();
+      const seen = new Set<string>(); // Track processed IDs to remove duplicates
 
       snapshots.forEach((snap: QuerySnapshot<DocumentData>) => {
         snap.docs.forEach((doc: QueryDocumentSnapshot<DocumentData>) => {
-          if (seen.has(doc.id)) return;
+          if (seen.has(doc.id)) return; // Skip notes already seen in other ranges
           const data = doc.data();
           const distanceInKm = distanceBetween([data.lat, data.lng], center);
           if (distanceInKm * 1000 <= RADIUS_M) {
-            seen.add(doc.id);
+            seen.add(doc.id); // Mark this note as processed
             const createdAtTimestamp = data.createdAt as Timestamp | null;
             notesData.push({
               id: doc.id,


### PR DESCRIPTION
## Summary
- document geolocation-based note fetching strategy and exposed state in `useNotes`
- clarify default search radius and note limit constants
- comment geohash boundary generation and duplicate filtering

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde7ccbea883218298e34e7b223a73