### PR TITLE
docs: document cn utility

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,13 @@
 import { clsx, type ClassValue } from "clsx"
 import { twMerge } from "tailwind-merge"
 
+/**
+ * Combines multiple Tailwind CSS class values into a single string.
+ *
+ * `clsx` handles conditional class expressions while `tailwind-merge`
+ * resolves conflicts, keeping the last occurrence of a utility. This
+ * simplifies dynamic class composition and ensures predictable styles.
+ */
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }


### PR DESCRIPTION
## Summary
- document `cn` helper explaining its Tailwind class merging benefits

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bde7d62de48321b82e68a5ea6b47f1