### PR TITLE
docs: improve guidance for ai contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,7 @@ This repository uses Next.js and TypeScript.
 - Only commit to main branch; do not create new branches.
 - Ensure new UI remains mobile-optimized with responsive layouts.
 - Include unit tests for hooks and utilities using Vitest when adding new logic.
+- Refer to `CONTRIBUTING.md` and `structure.md` for project layout and workflow details.
 
 ## Checks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing
+
+This project welcomes contributions from humans and AI assistants.
+
+## Getting Started
+
+1. Read [`AGENTS.md`](AGENTS.md) for repository conventions.
+2. Work directly off the `main` branch—do not create new branches.
+3. Use functional, type-safe React components and keep the UI mobile responsive.
+
+## Development Workflow
+
+Before committing, run:
+
+```bash
+npm run lint
+npm run typecheck
+npm test
+```
+
+Include or update tests when adding new hooks or utilities.
+
+## Resources
+
+- [`structure.md`](structure.md) describes the codebase layout.
+- [`docs/blueprint.md`](docs/blueprint.md) covers high-level features.
+
+Sharing these files with an AI assistant gives it the context needed to contribute effectively.
+

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ If not provided, the default radius is 50 meters.
 
 ## Documentation
 
-A high level project blueprint is available in [`docs/blueprint.md`](docs/blueprint.md).
+Key documents for orientation:
+
+- [`docs/blueprint.md`](docs/blueprint.md) – product goals and feature overview.
+- [`structure.md`](structure.md) – architecture and source layout.
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) – development workflow and coding guidelines.
 
 The main application entry point is [`src/app/page.tsx`](src/app/page.tsx).
+
+## AI Coding Notes
+
+When using an AI assistant, share the above files and [`AGENTS.md`](AGENTS.md) for context.
+Ensure generated code follows the existing style, includes tests for new logic,
+and passes `npm run lint`, `npm run typecheck`, and `npm test` before commit.

--- a/docs/blueprint.md
+++ b/docs/blueprint.md
@@ -19,3 +19,9 @@
 - Code font: 'Source Code Pro' for any displayed code snippets.
 - Custom sticky-note style markers for notes; compass overlay with arrow and distance indicator.
 - Mobile-first layout using bottom sheets for note details and creation; map view as primary interface.
+
+## Further Reading
+
+For implementation details see [structure.md](../structure.md).
+Contribution guidelines and coding conventions live in [CONTRIBUTING.md](../CONTRIBUTING.md)
+and [AGENTS.md](../AGENTS.md).

--- a/structure.md
+++ b/structure.md
@@ -104,3 +104,9 @@ Tests are colocated with the source they cover using `*.test.tsx` or `*.test.ts`
 Environment variables in `.env.local` configure Firebase and default proximity radius. Service workers and manifest files under `public/` enable PWA behaviour.
 
 This document should provide enough context for onboarding and further development without direct access to every source file.
+ 
+## AI Coding Tips
+
+- Review [`AGENTS.md`](AGENTS.md) and [`CONTRIBUTING.md`](CONTRIBUTING.md) before making changes.
+- Favor type-safe React components and keep layouts mobile responsive.
+- Update or add tests when modifying hooks or utilities.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING guide for human and AI developers
- expand README and structure docs with AI coding notes
- cross-link blueprint and AGENTS to new documentation

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdec679c7c8321821d63d3a0580855