### PR TITLE
feat: add label to notifications button

### DIFF
--- a/src/components/notifications-button.test.tsx
+++ b/src/components/notifications-button.test.tsx
@@ -41,6 +41,18 @@ beforeEach(() => {
 });
 
 describe('NotificationsButton', () => {
+  it('renders accessible label for screen readers', () => {
+    useAuthMock.mockReturnValue({ user: { uid: 'user1' } });
+    useNotificationsMock.mockReturnValue({
+      notifications: [],
+      markAllAsRead: vi.fn(),
+    });
+
+    const { getByRole } = render(<NotificationsButton />);
+    const button = getByRole('button', { name: /notifications/i });
+    expect(button).toBeTruthy();
+  });
+
   it('navigates to note when notification is selected', () => {
     const notification = {
       id: 'notif1',

--- a/src/components/notifications-button.tsx
+++ b/src/components/notifications-button.tsx
@@ -22,6 +22,7 @@ export function NotificationsButton() {
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="relative h-8 w-8 rounded-full">
           <Bell className="h-4 w-4 text-gold" />
+          <span className="sr-only">Notifications</span>
           {unread > 0 && (
             <span className="absolute top-0 right-0 inline-flex h-2 w-2 rounded-full bg-destructive" />
           )}

--- a/todo.md
+++ b/todo.md
@@ -5,7 +5,8 @@ This file tracks outstanding tasks for the project. Update the list as tasks are
 - [ ] Add offline status indicator to detect network loss
 - [ ] Cache note queries in `useNotes` to reduce Firestore reads
 - [ ] Add tests for `note-sheet-content` component
-- [ ] Improve notifications button accessibility with a label
+- [x] Improve notifications button accessibility with a label
+- [ ] Audit icon-only buttons for missing accessible labels
 - [ ] Document required environment variables
 - [ ] Add unit tests for content moderation flow
 - [ ] Introduce tests for report dialog component


### PR DESCRIPTION
## Summary
- add screen reader label to notifications button
- test button accessibility and navigation
- update todo list

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be05365f408321b20cd4ee23f44bad