### PR TITLE
ND-001: Offline status indicator

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { SettingsProvider } from '@/hooks/use-settings';
 import { NdSprite } from '@/components/ui/nd-sprite';
 import { Inter, Lexend } from 'next/font/google';
 import SketchSprite from '@/components/ui/SketchSprite';
+import { OfflineBanner } from '@/components/notifications/OfflineBanner';
 
 const fontSans = Inter({
   subsets: ['latin'],
@@ -73,6 +74,7 @@ export default function RootLayout({
         <ThemeProvider>
           <SettingsProvider>
             <AuthProvider>
+              <OfflineBanner />
               {children}
               <Toaster />
               <Pwa />

--- a/src/components/notifications/OfflineBanner.tsx
+++ b/src/components/notifications/OfflineBanner.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { useOnline } from "@/hooks/use-online";
+import { cn } from "@/lib/utils";
+
+/**
+ * Displays a warning banner when the app is offline.
+ */
+export function OfflineBanner() {
+  const { isOnline } = useOnline();
+  if (isOnline) return null;
+  return (
+    <div className={cn("bg-yellow-500 text-black text-center text-sm py-2")}
+         role="status">
+      You are offline. Some actions are disabled.
+    </div>
+  );
+}

--- a/src/hooks/use-online.test.ts
+++ b/src/hooks/use-online.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { renderHook, act } from "@testing-library/react";
+import { vi, describe, it, expect } from "vitest";
+import { useOnline } from "./use-online";
+
+// Mock useToast to avoid real toasts during tests
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+describe("useOnline", () => {
+  it("updates status on offline/online events", () => {
+    Object.defineProperty(navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
+    const { result } = renderHook(() => useOnline());
+    expect(result.current.isOnline).toBe(true);
+
+    act(() => {
+      Object.defineProperty(navigator, "onLine", {
+        configurable: true,
+        value: false,
+      });
+      window.dispatchEvent(new Event("offline"));
+    });
+    expect(result.current.isOnline).toBe(false);
+
+    act(() => {
+      Object.defineProperty(navigator, "onLine", {
+        configurable: true,
+        value: true,
+      });
+      window.dispatchEvent(new Event("online"));
+    });
+    expect(result.current.isOnline).toBe(true);
+  });
+});

--- a/src/hooks/use-online.ts
+++ b/src/hooks/use-online.ts
@@ -1,0 +1,57 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useToast } from "@/hooks/use-toast";
+
+/**
+ * Tracks the browser's online status and blocks network requests when offline.
+ *
+ * Returns:
+ * - `isOnline`: current online status.
+ * - `assertOnline`: helper that shows a toast and returns false when offline.
+ */
+export function useOnline() {
+  const { toast } = useToast();
+  const [isOnline, setIsOnline] = useState(typeof navigator !== "undefined" ? navigator.onLine : true);
+  const originalFetch = useRef<typeof fetch>();
+
+  useEffect(() => {
+    const updateStatus = () => setIsOnline(navigator.onLine);
+    window.addEventListener("online", updateStatus);
+    window.addEventListener("offline", updateStatus);
+    return () => {
+      window.removeEventListener("online", updateStatus);
+      window.removeEventListener("offline", updateStatus);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!originalFetch.current) {
+      originalFetch.current = globalThis.fetch;
+    }
+    if (isOnline) {
+      globalThis.fetch = originalFetch.current;
+    } else {
+      globalThis.fetch = async (...args) => {
+        toast({
+          title: "Offline",
+          description: "You're offline. Please try again when you're back online.",
+        });
+        return Promise.reject(new Error("offline"));
+      };
+    }
+  }, [isOnline, toast]);
+
+  const assertOnline = () => {
+    if (!isOnline) {
+      toast({
+        title: "Offline",
+        description: "You're offline. Please try again when you're back online.",
+      });
+      return false;
+    }
+    return true;
+  };
+
+  return { isOnline, assertOnline };
+}

--- a/todo.yaml
+++ b/todo.yaml
@@ -1,12 +1,12 @@
 meta:
   version: 3
   commands:
-    test: "npm run lint && npm run typecheck && npm test"
+    test: npm run lint && npm run typecheck && npm test
   conventions:
-    commit: "{id}: {short_title}"
+    commit: '{id}: {short_title}'
     trailers:
-      - "Task-ID: {id}"
-      - "Task-Status: {status}"   # 'doing' or 'done'
+      - 'Task-ID: {id}'
+      - 'Task-Status: {status}'
   main_mode:
     require_checks: true
     require_task_id_in_subject: true
@@ -43,7 +43,7 @@ tasks:
   - id: ND-001
     title: Offline status indicator
     priority: P0
-    status: todo
+    status: done
     tags:
       - ui
       - pwa
@@ -51,6 +51,7 @@ tasks:
       - src/components/notifications/OfflineBanner.tsx
       - src/hooks/use-online.ts
       - src/app/layout.tsx
+      - src/hooks/use-online.test.ts
     steps:
       - Create use-online hook (listen to window online/offline).
       - Render a top banner within 2s of going offline; hide within 2s of reconnect.


### PR DESCRIPTION
## Summary
- add `useOnline` hook to track connectivity and block fetches while offline
- show an `OfflineBanner` in app layout when connectivity drops
- cover `useOnline` hook with unit tests

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bebdacaa088321b90264793686bb5e