### PR TITLE
Add aria-labels to icon buttons and fix todo yaml

### DIFF
--- a/src/components/create-note-form.tsx
+++ b/src/components/create-note-form.tsx
@@ -317,6 +317,7 @@ export default function CreateNoteForm({
                 size="icon"
                 className="absolute top-2 right-2 h-6 w-6"
                 onClick={handleRemoveImage}
+                aria-label="Remove image"
               >
                 <X className="h-4 w-4" />
               </Button>
@@ -343,6 +344,7 @@ export default function CreateNoteForm({
             type="button"
             onClick={() => fileInputRef.current?.click()}
             disabled={isSubmitting}
+            aria-label="Add image"
           >
             <Camera className="h-4 w-4" />
           </Button>

--- a/src/components/map-view.tsx
+++ b/src/components/map-view.tsx
@@ -407,6 +407,7 @@ function MapViewContent() {
 
       <Button
         className="absolute right-4 rounded-full w-12 h-12 shadow-lg bottom-20 sm:bottom-24 sm:w-14 sm:h-14"
+        aria-label="Add note"
         onClick={() => {
             setCreatingNote(true);
             setSelectedNote(null);
@@ -423,6 +424,7 @@ function MapViewContent() {
         className="absolute right-4 rounded-full w-12 h-12 shadow-lg bottom-36 sm:bottom-40 sm:w-14 sm:h-14"
         onClick={handleCenterMap}
         disabled={!location}
+        aria-label="Center map"
       >
         <LocateFixed className="w-6 h-6" />
       </Button>

--- a/src/components/reply-form.test.tsx
+++ b/src/components/reply-form.test.tsx
@@ -48,4 +48,9 @@ describe("ReplyForm", () => {
     expect(textarea.value.length).toBe(120);
     screen.getByText("120/120");
   });
+
+  it("has an accessible send button", () => {
+    render(<ReplyForm noteId="1" />);
+    expect(screen.getByRole("button", { name: /send reply/i })).toBeTruthy();
+  });
 });

--- a/src/components/reply-form.tsx
+++ b/src/components/reply-form.tsx
@@ -114,7 +114,13 @@ export default function ReplyForm({
         <p className="text-xs text-muted-foreground text-right">{text.length}/120</p>
         {error && <p className="text-sm text-destructive mt-1">{error}</p>}
       </div>
-      <Button type="submit" size="icon" className="h-full" disabled={isSubmitting}>
+      <Button
+        type="submit"
+        size="icon"
+        className="h-full"
+        disabled={isSubmitting}
+        aria-label="Send reply"
+      >
         {isSubmitting ? (
           <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current"></div>
         ) : (

--- a/todo.yaml
+++ b/todo.yaml
@@ -105,7 +105,7 @@ tasks:
   - id: ND-005
     title: Audit icon-only buttons for accessible labels
     priority: P1
-    status: todo
+    status: done
     tags:
       - a11y
       - ui
@@ -341,7 +341,7 @@ tasks:
       - Review `npm audit` and run `npm audit fix` where safe.
       - Pin or replace vulnerable dependencies.
     acceptance:
-      - `npm audit` reports 0 critical/high vulnerabilities.
+      - "`npm audit` reports 0 critical/high vulnerabilities."
     notes: ''
   - id: ND-019
     title: Fix MapView test mock to forward ref
@@ -381,4 +381,17 @@ tasks:
       - Ensure mock does not pass `onOpenChange` to DOM elements.
     acceptance:
       - No warning about unknown event handler `onOpenChange`.
+    notes: ''
+  - id: ND-022
+    title: Fix todo.yaml indentation to allow task parsing
+    priority: P0
+    status: done
+    tags:
+      - tooling
+    files:
+      - todo.yaml
+    steps:
+      - Correct malformed indentation in ND-018 entry.
+    acceptance:
+      - ts-node scripts/task-tools.ts next runs without YAML errors.
     notes: ''


### PR DESCRIPTION
## Summary
- fix todo.yaml indentation and add ND-022 task so backlog parsing works
- add aria-labels to icon-only buttons and test for accessible send button

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68befe094340832188301a5d4bf157a5