### PR TITLE
ND-029: sync todo lists

### DIFF
--- a/todo.md
+++ b/todo.md
@@ -2,16 +2,21 @@
 
 This file tracks outstanding tasks for the project. Update the list as tasks are added or completed.
 
-- [ ] Add offline status indicator to detect network loss
-- [ ] Cache note queries in `useNotes` to reduce Firestore reads
-- [x] Add tests for `note-sheet-content` component
-- [x] Improve notifications button accessibility with a label
-- [ ] Audit icon-only buttons for missing accessible labels
+- [x] Offline status indicator
+- [x] Cache note queries in useNotes to reduce Firestore reads
+- [x] Tests for note-sheet-content component
+- [x] Notifications button has accessible label
+- [x] Audit icon-only buttons for accessible labels
 - [x] Document required environment variables
-- [ ] Add unit tests for content moderation flow
-- [ ] Introduce tests for report dialog component
-- [ ] Add rate limiting to `reportNoteFlow`
-- [ ] Cache note images in service worker
-- [ ] Strengthen validation in notify API route
+- [x] Unit tests for content moderation flow
+- [x] Tests for report dialog component
+- [x] Rate limiting for reportNoteFlow
+- [ ] Service Worker: cache note images (SWR)
+- [x] Strengthen validation in notify API route
 - [x] Provide `.env.example` with placeholder values and remove real API keys
-- [ ] Add tests for notify API route
+- [x] Tests for notify API route
+- [ ] Document NOTIFY_SECRET environment variable
+- [ ] Remove unused exports (150) across 42 files
+- [ ] Fix MapView test mock to forward ref
+- [ ] Adjust next/image mock to avoid fill boolean attribute
+- [ ] Clean up DropdownMenu mock to handle onOpenChange

--- a/todo.yaml
+++ b/todo.yaml
@@ -416,3 +416,19 @@ tasks:
       - Dialog discoverable by role and name for screen readers.
       - Single submit button becomes disabled during pending.
     notes: ''
+  - id: ND-029
+    title: Sync todo lists
+    priority: P2
+    status: done
+    tags:
+      - docs
+      - meta
+    files:
+      - todo.md
+      - todo.yaml
+    steps:
+      - Mark completed tasks in todo.md based on todo.yaml
+      - Add missing tasks from backlog to todo.md
+    acceptance:
+      - todo.md matches tasks and statuses in todo.yaml
+    notes: ''


### PR DESCRIPTION
## Summary
- Mark previously completed tasks in todo.md and add outstanding items to mirror todo.yaml
- Record ND-029 backlog entry for syncing todo lists

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf2fa79fe48321b26688cc15b6f46a